### PR TITLE
fix: restore usage indicator and fix token calculation issues

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -731,9 +731,7 @@ export const generateAIResponseWithMessage = internalAction({
       const generationOptions: Parameters<typeof streamText>[0] = {
         model: ai(actualModelName),
         messages: messages,
-        onFinish: async (event) => {
-          await updateUsage(event.usage)
-        },
+        // Usage will be updated after streaming completes
       }
 
       // Add web search tool if enabled
@@ -1541,15 +1539,8 @@ export const completeStreamingMessageLegacy = internalMutation({
       usage: args.usage,
     })
 
-    // Update thread usage totals atomically if we have usage data
-    if (args.usage && message.threadId) {
-      await updateThreadUsage(
-        ctx,
-        message.threadId,
-        message.modelId || message.model || "unknown",
-        args.usage,
-      )
-    }
+    // Thread usage has already been updated via updateUsage during streaming
+    // No need to update again here to avoid double counting
 
     return null
   },
@@ -1588,15 +1579,8 @@ export const completeStreamingMessage = internalMutation({
       usage: args.usage,
     })
 
-    // Update thread usage totals atomically if we have usage data
-    if (args.usage && message.threadId) {
-      await updateThreadUsage(
-        ctx,
-        message.threadId,
-        message.modelId || message.model || "unknown",
-        args.usage,
-      )
-    }
+    // Thread usage has already been updated via updateUsage during streaming
+    // No need to update again here to avoid double counting
 
     return null
   },

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1222,6 +1222,26 @@ REMEMBER:
 
       console.log("Formatted usage:", formattedUsage)
 
+      // Update thread usage if we have usage data
+      if (finalUsage) {
+        const promptTokens = finalUsage.inputTokens || 0
+        const completionTokens = finalUsage.outputTokens || 0
+        const totalTokens =
+          finalUsage.totalTokens || promptTokens + completionTokens
+
+        await ctx.runMutation(internal.messages.updateThreadUsageMutation, {
+          threadId: args.threadId,
+          usage: {
+            promptTokens,
+            completionTokens,
+            totalTokens,
+            reasoningTokens: finalUsage.reasoningTokens || 0,
+            cachedTokens: finalUsage.cachedInputTokens || 0,
+            modelId: args.modelId,
+          },
+        })
+      }
+
       // Ensure we always have some content to complete with, even if just tool results
       if (fullContent.trim() === "" && toolCallsProcessed === 0) {
         fullContent =

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -6,6 +6,7 @@ import {
 import { Suspense } from "react"
 import { ChatTitleClient } from "./ChatTitleClient"
 import { ShareButtonWrapper } from "./ShareButtonWrapper"
+import { TokenUsageHeaderWrapper } from "./TokenUsageHeaderWrapper"
 import { ServerSidebar } from "./sidebar/ServerSidebar"
 
 // Server component for chat header - can be static with PPR
@@ -21,7 +22,7 @@ function ChatHeader() {
         </Suspense>
       </div>
       <div className="flex items-center gap-1 sm:gap-2">
-        {/* <Suspense
+        <Suspense
           fallback={
             <div className="flex items-center gap-2">
               <div className="h-6 w-16 bg-muted animate-pulse rounded" />
@@ -30,7 +31,7 @@ function ChatHeader() {
           }
         >
           <TokenUsageHeaderWrapper />
-        </Suspense> */}
+        </Suspense>
         <Suspense
           fallback={<div className="h-8 w-16 bg-muted animate-pulse rounded" />}
         >


### PR DESCRIPTION
## Summary
- Restored the usage indicator in chat header that was commented out
- Fixed triple counting of tokens (was showing 3x the actual usage)
- Fixed subsequent messages not updating thread usage totals
- Improved token calculation when AI SDK doesn't provide totalTokens

## Changes
1. **Usage indicator display**: Uncommented `TokenUsageHeaderWrapper` in ChatLayout
2. **Token calculation**: Calculate `totalTokens` as `inputTokens + outputTokens` when not provided
3. **Removed duplicate counting**: 
   - Removed updateUsage from onFinish callback
   - Removed updateThreadUsage from completeStreamingMessage functions
4. **Fixed subsequent messages**: Added usage update to `generateAIResponse` 

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Verify usage indicator shows in chat header
- [ ] Verify first message updates usage correctly
- [ ] Verify subsequent messages update usage correctly
- [ ] Verify totals match sum of individual messages

Fixes token usage tracking issues where usage was being triple-counted and subsequent messages weren't being tracked.

🤖 Generated with [Claude Code](https://claude.ai/code)