### PR TITLE
fix: initialize message usage data to prevent 0/0 token display

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -290,6 +290,13 @@ export const send = mutation({
       model: provider,
       modelId: modelId,
       attachments: args.attachments,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
     })
 
     // Schedule AI response using the modelId
@@ -386,6 +393,13 @@ export const createThreadAndSend = mutation({
       model: provider,
       modelId: modelId,
       attachments: args.attachments,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
     })
 
     // Generate unique stream ID for assistant message
@@ -406,6 +420,13 @@ export const createThreadAndSend = mutation({
       streamChunks: [], // Initialize empty chunks array
       streamVersion: 0, // Initialize version counter
       lastChunkId: undefined, // Initialize last chunk ID
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
     })
 
     // Schedule AI response with the pre-created message ID
@@ -1354,6 +1375,13 @@ export const createStreamingMessage = internalMutation({
       lastChunkId: undefined, // Initialize last chunk ID
       modelId: args.modelId,
       usedUserApiKey: args.usedUserApiKey,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
     })
   },
 })


### PR DESCRIPTION
## Summary
- Fixed token usage showing 0/0 for input/output during first user message and assistant reply
- Root cause: Messages were created without proper usage initialization, causing undefined values
- Applied consistent usage structure initialization across all message creation paths

## Changes
- **send mutation**: Initialize user messages with zero token usage structure
- **createThreadAndSend mutation**: Initialize both user and assistant messages with usage data
- **createStreamingMessage**: Ensure assistant message placeholders have proper usage initialization

## Technical Details
The TokenUsageDialog was displaying 0/0 because:
1. User messages had `undefined` usage instead of zero values
2. Assistant message placeholders started with `undefined` usage
3. Thread usage aggregation couldn't properly handle undefined values

Now all messages start with proper zero-initialized usage structures that get updated with real data from the AI SDK when responses complete.

## Test Plan
- [x] Build passes successfully
- [ ] Create new chat and verify token usage displays properly from first exchange
- [ ] Verify subsequent messages show correct token counts
- [ ] Check both user and assistant message breakdowns in dialog

🤖 Generated with [Claude Code](https://claude.ai/code)