### PR TITLE
fix: make streamChunks schema backward compatible with legacy data

### DIFF
--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -98,11 +98,14 @@ export const tokenUsageValidator = v.optional(
   }),
 )
 
-// Stream chunk validator
+// Stream chunk validator - backward compatible with old "id" field
 export const streamChunkValidator = v.object({
-  chunkId: chunkIdValidator,
+  // Support both old "id" field and new "chunkId" field for backward compatibility
+  chunkId: v.optional(chunkIdValidator),
+  id: v.optional(chunkIdValidator), // Legacy field from before PR #195
   content: v.string(),
   timestamp: v.number(),
+  sequence: v.optional(v.number()), // Legacy field from before PR #195
   isThinking: v.optional(v.boolean()),
 })
 

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -31,7 +31,6 @@ export {
   ANTHROPIC_MODEL_IDS,
   OPENROUTER_MODEL_IDS,
   MODEL_PROVIDERS,
-  
   // Model functions
   getModelConfig,
   getModelsForProvider,
@@ -41,22 +40,18 @@ export {
   getModelDisplayName,
   modelSupportsFeature,
   getLegacyModelMapping,
-  
   // Model utilities
   isValidModelId,
   getProviderFromModelId,
   getActualModelName,
   isThinkingMode,
-  
   // API key validation
   validateApiKey,
-  
   // Legacy collections (deprecated)
   OPENAI_MODELS,
   ANTHROPIC_MODELS,
   OPENROUTER_MODELS,
   ALL_MODELS,
-  
   // Legacy function aliases (deprecated)
   getModelsByProvider,
   getAllModels,


### PR DESCRIPTION
## Summary

Fixes the production deployment schema validation error that occurred after PR #195 was merged.

- **Root Cause**: PR #195 changed `streamChunks` schema from using `id` to `chunkId` field, but existing production data still uses the old format
- **Solution**: Made schema backward compatible by supporting both old and new field formats
- **Impact**: Allows production deployment to succeed without requiring data migration

## Changes

- Made `chunkId` and `id` fields optional in `streamChunkValidator`
- Added support for legacy `sequence` field
- Added descriptive comments explaining backward compatibility

## Error Fixed

```
Document with ID "j97001x3g0wv953aeq4a6zt2sd7j3me4" in table "messages" does not match the schema: Object is missing the required field `chunkId`.
Path: .streamChunks[0]
Object: {content: "A", id: "1750249743390_hehkwtb84", sequence: 0.0, timestamp: 1750249743392.0}
```

## Test Plan

- [x] Production build passes (`bun run build`)
- [x] Linting passes (`bun run lint`)
- [x] Formatting passes (`bun run format`)
- [x] Schema validates existing legacy data format
- [x] Schema supports new data format from PR #195

🤖 Generated with [Claude Code](https://claude.ai/code)