### PR TITLE
fix: restore original site-header appearance by hiding docs link

### DIFF
--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -73,10 +73,7 @@ export const metadata: Metadata = {
 function LandingPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
-      <SiteHeader
-        githubUrl={siteConfig.links.github.href}
-        docsUrl={siteConfig.links.docs.href}
-      />
+      <SiteHeader githubUrl={siteConfig.links.github.href} showDocs={false} />
 
       {/* Main content */}
       <main className="flex-1 container mx-auto px-4 py-48">


### PR DESCRIPTION
## Summary
- Restores the original landing page header design
- Site-footer already matches the original implementation

## Changes
- Set `showDocs={false}` on the SiteHeader component in the landing page
- This hides the "Docs" link that was added during the monorepo migration
- The original landing header only had Logo, GitHub link, and Sign In button

## Test plan
- [x] Build passes with `SKIP_ENV_VALIDATION=true DOCS_URL=https://docs.lightfast.ai bun run build`
- [x] Lint passes and fixed formatting issues
- [ ] Visual verification on Vercel preview deployment

🤖 Generated with [Claude Code](https://claude.ai/code)