### PR TITLE
refactor: centralize env:sync and convex commands to run from root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,25 @@
-# Deployment used by `npx convex dev`
-CONVEX_DEPLOYMENT=anonymous:anonymous-lightfast-chat
+# Convex Configuration
+NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210  # For local development
+CONVEX_DEPLOYMENT=your-convex-deployment-url   # For production
 
-NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3212
+# AI API Keys (Required for AI responses)
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key-here  # Required for Claude Sonnet 4 (default)
+OPENAI_API_KEY=sk-your-openai-api-key-here            # Required for GPT models
+OPENROUTER_API_KEY=sk-or-your-openrouter-key-here     # Required for additional AI models
+EXA_API_KEY=your-exa-api-key-here                     # Required for web search functionality
+
+# Authentication
+AUTH_GITHUB_ID=your-github-oauth-client-id             # Required for GitHub OAuth
+AUTH_GITHUB_SECRET=your-github-oauth-client-secret     # Required for GitHub OAuth
+JWT_PRIVATE_KEY=your-jwt-private-key                  # Required for API key encryption
+JWKS=your-jwks-json-string                            # Required for JWT verification (JSON format)
+ENCRYPTION_KEY=your-encryption-key                    # Optional fallback encryption key
+
+# Convex Configuration (optional)
+CONVEX_SITE_URL=https://your-site-url.com             # Optional for auth configuration
+
+# Vercel Environment (optional)
+NEXT_PUBLIC_VERCEL_ENV=development                     # deployment environment
+
+# Node Environment
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,3 @@ tmp_context/
 # Claude Code context files
 .claude-context.md
 
-# Convex generated files in root (should only be in apps/www)
-/convex/

--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,3 @@ tmp_context/
 
 # Convex generated files in root (should only be in apps/www)
 /convex/
-/convex.json

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ tmp_context/
 
 # Convex generated files in root (should only be in apps/www)
 /convex/
+/convex.json

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ tmp_context/
 
 # Claude Code context files
 .claude-context.md
+
+# Convex generated files in root (should only be in apps/www)
+/convex/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ git worktree add worktrees/<feature_name> -b jeevanpillay/<feature_name>
 cd worktrees/<feature_name>
 pnpm install
 cp ../../.env.local apps/www/.env.local
-pnpm run env:sync
+pnpm run env:sync  # Run from root - Vercel links apps/www env to root
 ```
 
 ### Step 4: Development Cycle
@@ -542,8 +542,11 @@ cd apps/www && SKIP_ENV_VALIDATION=true pnpm run build
 pnpm run lint
 pnpm run format
 
-# Environment sync (from apps/www - auto-detects .env.local location)
-cd apps/www && pnpm run env:sync
+# Environment sync (from root - auto-detects apps/www/.env.local)
+pnpm run env:sync
+
+# Convex development (from root)
+pnpm run convex:dev
 ```
 
 ### Context Management
@@ -624,6 +627,7 @@ This is a Turborepo monorepo with the following structure:
 pnpm run dev             # Run all apps in dev mode
 pnpm run dev:www        # Run www app (Next.js + Convex concurrently)
 pnpm run dev:docs       # Run only docs app
+pnpm run convex:dev     # Run Convex dev server (from root, executes in apps/www)
 
 # Building
 pnpm run build          # Build all apps
@@ -635,7 +639,7 @@ pnpm run ui:add <component>  # Add new shadcn component
 pnpm run ui:diff            # Check for component updates
 
 # Environment Management
-pnpm run env:sync       # Sync environment variables to Convex
+pnpm run env:sync       # Sync environment variables to Convex (from root - Vercel links apps/www/.env.local to root)
 pnpm run env:check      # Check environment variables in Convex
 
 # Quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,8 +346,8 @@ mkdir -p worktrees
 git worktree add worktrees/<feature_name> -b jeevanpillay/<feature_name>
 cd worktrees/<feature_name>
 pnpm install
-cp ../../.env.local apps/www/.env.local
-pnpm run env:sync  # Run from root - Vercel links apps/www env to root
+# .env.local should already be in root directory
+pnpm run env:sync  # Run from root with .env.local in root
 ```
 
 ### Step 4: Development Cycle
@@ -542,7 +542,7 @@ cd apps/www && SKIP_ENV_VALIDATION=true pnpm run build
 pnpm run lint
 pnpm run format
 
-# Environment sync (from root - auto-detects apps/www/.env.local)
+# Environment sync (from root with .env.local in root)
 pnpm run env:sync
 
 # Convex development (from root)
@@ -639,7 +639,7 @@ pnpm run ui:add <component>  # Add new shadcn component
 pnpm run ui:diff            # Check for component updates
 
 # Environment Management
-pnpm run env:sync       # Sync environment variables to Convex (from root - Vercel links apps/www/.env.local to root)
+pnpm run env:sync       # Sync environment variables to Convex (run from root with .env.local in root)
 pnpm run env:check      # Check environment variables in Convex
 
 # Quality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ cp .env.example .env.local
 # Edit .env.local with your API keys
 # Required: ANTHROPIC_API_KEY, OPENAI_API_KEY, AUTH_GITHUB_ID, AUTH_GITHUB_SECRET
 
-# Sync environment variables to Convex
+# Sync environment variables to Convex (run from root - auto-detects apps/www/.env.local)
 pnpm run env:sync
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ cp .env.example .env.local
 # Edit .env.local with your API keys
 # Required: ANTHROPIC_API_KEY, OPENAI_API_KEY, AUTH_GITHUB_ID, AUTH_GITHUB_SECRET
 
-# Sync environment variables to Convex (run from root - auto-detects apps/www/.env.local)
+# Sync environment variables to Convex (run from root with .env.local in root)
 pnpm run env:sync
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ SKIP_ENV_VALIDATION=true pnpm run build
    pnpm install
    ```
 
-2. Set up your environment variables (create `.env.local` in the root directory with the variables shown above)
+2. Copy the example environment file and configure it:
+   ```bash
+   cp .env.example .env.local
+   # Edit .env.local with your API keys and configuration
+   ```
 
 3. Set up GitHub OAuth (see Authentication Setup section above)
 
@@ -209,10 +213,10 @@ SKIP_ENV_VALIDATION=true pnpm run build
    
    **Alternative**: If you prefer separate terminals:
    ```bash
-   # Terminal 1: Start Convex development server (from root)
+   # Terminal 1: Start Convex development server
    pnpm run convex:dev
    
-   # Terminal 2: Start Next.js development server only (from apps/www)
+   # Terminal 2: Start Next.js development server only
    cd apps/www && pnpm run dev:next
    ```
 
@@ -314,7 +318,7 @@ SKIP_ENV_VALIDATION=true pnpm run build
 ### Development Servers
 - `pnpm run dev:www` - Start Next.js + Convex concurrently
 - `pnpm run dev:next` - Start Next.js development server only (run from apps/www)
-- `pnpm run convex:dev` - Start Convex development server (from root, executes in apps/www)
+- `pnpm run convex:dev` - Start Convex development server (run from root)
 - `pnpm run convex:deploy` - Deploy to Convex (run from apps/www)
 - `pnpm run env:sync` - Sync environment variables to Convex (run from root with .env.local in root)
 
@@ -401,7 +405,7 @@ Simply visit [chat.lightfast.ai](https://chat.lightfast.ai) and start chatting w
    ```bash
    cp .env.example .env.local
    # Edit .env.local with your API keys
-   pnpm run env:sync  # Auto-detects apps/www/.env.local
+   pnpm run env:sync
    ```
 
 5. **Deploy Convex functions**

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ AUTH_GITHUB_SECRET=your_github_client_secret_here
 Run the sync script to push environment variables to Convex:
 
 ```bash
-pnpm run env:sync
+pnpm run env:sync  # Run from root - auto-detects apps/www/.env.local
 ```
 
 ### Usage
@@ -185,18 +185,19 @@ SKIP_ENV_VALIDATION=true pnpm run build
    pnpm install
    ```
 
-2. Set up your environment variables (create `.env.local` with the variables shown above)
+2. Set up your environment variables (create `.env.local` in `apps/www/` directory with the variables shown above)
 
 3. Set up GitHub OAuth (see Authentication Setup section above)
 
 4. Sync environment variables to Convex:
    ```bash
-   pnpm run env:sync
+   pnpm run env:sync  # Run from root - auto-detects apps/www/.env.local
    ```
    
    This command will:
    - Validate all required environment variables
    - Sync API keys and authentication settings to Convex
+   - Use the `.env.local` file that Vercel links from `apps/www/` to root
    - Automatically set NODE_ENV=development for local development
 
 5. Start the development servers (Next.js + Convex concurrently):
@@ -208,11 +209,11 @@ SKIP_ENV_VALIDATION=true pnpm run build
    
    **Alternative**: If you prefer separate terminals:
    ```bash
-   # Terminal 1: Start Convex development server
+   # Terminal 1: Start Convex development server (from root)
    pnpm run convex:dev
    
-   # Terminal 2: Start Next.js development server only
-   pnpm run dev:next
+   # Terminal 2: Start Next.js development server only (from apps/www)
+   cd apps/www && pnpm run dev:next
    ```
 
 6. Open [http://localhost:3000](http://localhost:3000) and sign in with GitHub
@@ -312,10 +313,10 @@ SKIP_ENV_VALIDATION=true pnpm run build
 
 ### Development Servers
 - `pnpm run dev:www` - Start Next.js + Convex concurrently
-- `pnpm run dev:next` - Start Next.js development server only
-- `pnpm run convex:dev` - Start Convex development server only
-- `pnpm run convex:deploy` - Deploy to Convex
-- `pnpm run env:sync` - Sync environment variables to Convex
+- `pnpm run dev:next` - Start Next.js development server only (run from apps/www)
+- `pnpm run convex:dev` - Start Convex development server (from root, executes in apps/www)
+- `pnpm run convex:deploy` - Deploy to Convex (run from apps/www)
+- `pnpm run env:sync` - Sync environment variables to Convex (from root - auto-detects apps/www/.env.local)
 
 ### UI Components
 - `pnpm run ui:add <component>` - Add a new shadcn/ui component
@@ -393,14 +394,14 @@ Simply visit [chat.lightfast.ai](https://chat.lightfast.ai) and start chatting w
 
 3. **Set up Convex**
    ```bash
-   pnpm exec convex dev  # Follow the setup prompts
+   pnpm run convex:dev  # Follow the setup prompts
    ```
 
 4. **Configure environment variables**
    ```bash
-   cp .env.example .env.local
-   # Edit .env.local with your API keys
-   pnpm run env:sync
+   cp .env.example apps/www/.env.local
+   # Edit apps/www/.env.local with your API keys
+   pnpm run env:sync  # Auto-detects apps/www/.env.local
    ```
 
 5. **Deploy Convex functions**

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ AUTH_GITHUB_SECRET=your_github_client_secret_here
 Run the sync script to push environment variables to Convex:
 
 ```bash
-pnpm run env:sync  # Run from root - auto-detects apps/www/.env.local
+pnpm run env:sync  # Run from root with .env.local in root directory
 ```
 
 ### Usage
@@ -185,19 +185,19 @@ SKIP_ENV_VALIDATION=true pnpm run build
    pnpm install
    ```
 
-2. Set up your environment variables (create `.env.local` in `apps/www/` directory with the variables shown above)
+2. Set up your environment variables (create `.env.local` in the root directory with the variables shown above)
 
 3. Set up GitHub OAuth (see Authentication Setup section above)
 
 4. Sync environment variables to Convex:
    ```bash
-   pnpm run env:sync  # Run from root - auto-detects apps/www/.env.local
+   pnpm run env:sync  # Run from root with .env.local in root directory
    ```
    
    This command will:
    - Validate all required environment variables
    - Sync API keys and authentication settings to Convex
-   - Use the `.env.local` file that Vercel links from `apps/www/` to root
+   - Use the `.env.local` file from the root directory
    - Automatically set NODE_ENV=development for local development
 
 5. Start the development servers (Next.js + Convex concurrently):
@@ -316,7 +316,7 @@ SKIP_ENV_VALIDATION=true pnpm run build
 - `pnpm run dev:next` - Start Next.js development server only (run from apps/www)
 - `pnpm run convex:dev` - Start Convex development server (from root, executes in apps/www)
 - `pnpm run convex:deploy` - Deploy to Convex (run from apps/www)
-- `pnpm run env:sync` - Sync environment variables to Convex (from root - auto-detects apps/www/.env.local)
+- `pnpm run env:sync` - Sync environment variables to Convex (run from root with .env.local in root)
 
 ### UI Components
 - `pnpm run ui:add <component>` - Add a new shadcn/ui component
@@ -399,8 +399,8 @@ Simply visit [chat.lightfast.ai](https://chat.lightfast.ai) and start chatting w
 
 4. **Configure environment variables**
    ```bash
-   cp .env.example apps/www/.env.local
-   # Edit apps/www/.env.local with your API keys
+   cp .env.example .env.local
+   # Edit .env.local with your API keys
    pnpm run env:sync  # Auto-detects apps/www/.env.local
    ```
 

--- a/apps/CLAUDE.md
+++ b/apps/CLAUDE.md
@@ -76,7 +76,7 @@ pnpm run build:www   # Build for production
 pnpm run dev         # Run dev server
 pnpm run build       # Build for production
 pnpm run convex:dev  # Run Convex dev server
-pnpm run env:sync    # Sync environment variables
+pnpm run env:sync    # Sync environment variables (auto-detects .env.local location)
 ```
 
 ### Deployment

--- a/apps/CLAUDE.md
+++ b/apps/CLAUDE.md
@@ -23,8 +23,7 @@ apps/www/
 │   │   └── settings/    # Settings components
 │   └── lib/             # Utilities and helpers
 ├── convex/              # Backend (see convex/CLAUDE.md)
-├── public/              # Static assets
-└── .env.local          # Environment variables
+└── public/              # Static assets
 ```
 
 ### Key Patterns

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -39,10 +39,7 @@ pnpm install
 # Copy environment template
 cp apps/www/.env.example apps/www/.env.local
 
-# Navigate to the main app
-cd apps/www
-
-# Sync environment variables to Convex
+# Sync environment variables to Convex (from root - auto-detects apps/www/.env.local)
 pnpm run env:sync
 ```
 

--- a/apps/www/.gitignore
+++ b/apps/www/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/apps/www/convex/_generated/api.d.ts
+++ b/apps/www/convex/_generated/api.d.ts
@@ -9,9 +9,9 @@
  */
 
 import type {
-	ApiFromModules,
-	FilterApi,
-	FunctionReference,
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
 } from "convex/server";
 import type * as auth from "../auth.js";
 import type * as env from "../env.js";
@@ -26,13 +26,13 @@ import type * as lib_encryption from "../lib/encryption.js";
 import type * as lib_errors from "../lib/errors.js";
 import type * as lib_message_builder from "../lib/message_builder.js";
 import type * as lib_message_service from "../lib/message_service.js";
-import type * as messages from "../messages.js";
 import type * as messages_actions from "../messages/actions.js";
 import type * as messages_helpers from "../messages/helpers.js";
 import type * as messages_mutations from "../messages/mutations.js";
 import type * as messages_queries from "../messages/queries.js";
 import type * as messages_tools from "../messages/tools.js";
 import type * as messages_types from "../messages/types.js";
+import type * as messages from "../messages.js";
 import type * as setup from "../setup.js";
 import type * as share from "../share.js";
 import type * as threads from "../threads.js";
@@ -50,39 +50,39 @@ import type * as validators from "../validators.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
-	auth: typeof auth;
-	env: typeof env;
-	feedback: typeof feedback;
-	files: typeof files;
-	http: typeof http;
-	"lib/ai_client": typeof lib_ai_client;
-	"lib/ai_tools": typeof lib_ai_tools;
-	"lib/auth": typeof lib_auth;
-	"lib/database": typeof lib_database;
-	"lib/encryption": typeof lib_encryption;
-	"lib/errors": typeof lib_errors;
-	"lib/message_builder": typeof lib_message_builder;
-	"lib/message_service": typeof lib_message_service;
-	"messages/actions": typeof messages_actions;
-	"messages/helpers": typeof messages_helpers;
-	"messages/mutations": typeof messages_mutations;
-	"messages/queries": typeof messages_queries;
-	"messages/tools": typeof messages_tools;
-	"messages/types": typeof messages_types;
-	messages: typeof messages;
-	setup: typeof setup;
-	share: typeof share;
-	threads: typeof threads;
-	titles: typeof titles;
-	userSettings: typeof userSettings;
-	users: typeof users;
-	validators: typeof validators;
+  auth: typeof auth;
+  env: typeof env;
+  feedback: typeof feedback;
+  files: typeof files;
+  http: typeof http;
+  "lib/ai_client": typeof lib_ai_client;
+  "lib/ai_tools": typeof lib_ai_tools;
+  "lib/auth": typeof lib_auth;
+  "lib/database": typeof lib_database;
+  "lib/encryption": typeof lib_encryption;
+  "lib/errors": typeof lib_errors;
+  "lib/message_builder": typeof lib_message_builder;
+  "lib/message_service": typeof lib_message_service;
+  "messages/actions": typeof messages_actions;
+  "messages/helpers": typeof messages_helpers;
+  "messages/mutations": typeof messages_mutations;
+  "messages/queries": typeof messages_queries;
+  "messages/tools": typeof messages_tools;
+  "messages/types": typeof messages_types;
+  messages: typeof messages;
+  setup: typeof setup;
+  share: typeof share;
+  threads: typeof threads;
+  titles: typeof titles;
+  userSettings: typeof userSettings;
+  users: typeof users;
+  validators: typeof validators;
 }>;
 export declare const api: FilterApi<
-	typeof fullApi,
-	FunctionReference<any, "public">
+  typeof fullApi,
+  FunctionReference<any, "public">
 >;
 export declare const internal: FilterApi<
-	typeof fullApi,
-	FunctionReference<any, "internal">
+  typeof fullApi,
+  FunctionReference<any, "internal">
 >;

--- a/apps/www/convex/_generated/dataModel.d.ts
+++ b/apps/www/convex/_generated/dataModel.d.ts
@@ -9,13 +9,13 @@
  */
 
 import type {
-	DataModelFromSchemaDefinition,
-	DocumentByName,
-	SystemTableNames,
-	TableNamesInDataModel,
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
 } from "convex/server";
 import type { GenericId } from "convex/values";
-import type schema from "../schema.js";
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
@@ -28,8 +28,8 @@ export type TableNames = TableNamesInDataModel<DataModel>;
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Doc<TableName extends TableNames> = DocumentByName<
-	DataModel,
-	TableName
+  DataModel,
+  TableName
 >;
 
 /**
@@ -46,7 +46,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
-	GenericId<TableName>;
+  GenericId<TableName>;
 
 /**
  * A type describing your Convex data model.

--- a/apps/www/convex/_generated/server.d.ts
+++ b/apps/www/convex/_generated/server.d.ts
@@ -8,16 +8,16 @@
  * @module
  */
 
-import type {
-	ActionBuilder,
-	GenericActionCtx,
-	GenericDatabaseReader,
-	GenericDatabaseWriter,
-	GenericMutationCtx,
-	GenericQueryCtx,
-	HttpActionBuilder,
-	MutationBuilder,
-	QueryBuilder,
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
 

--- a/apps/www/convex/_generated/server.js
+++ b/apps/www/convex/_generated/server.js
@@ -9,13 +9,13 @@
  */
 
 import {
-	actionGeneric,
-	httpActionGeneric,
-	internalActionGeneric,
-	internalMutationGeneric,
-	internalQueryGeneric,
-	mutationGeneric,
-	queryGeneric,
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
 } from "convex/server";
 
 /**

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -13,7 +13,6 @@
 		"typecheck": "tsc --noEmit",
 		"convex:dev": "convex dev",
 		"convex:deploy": "convex deploy",
-		"env:sync": "tsx ../../scripts/sync-env.ts",
 		"with-env": "dotenv -e ./.env.local --"
 	},
 	"dependencies": {

--- a/convex.json
+++ b/convex.json
@@ -1,0 +1,3 @@
+{
+  "functions": "apps/www/convex"
+}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "vercel-build": "cd apps/www && pnpx convex deploy --cmd 'turbo build --filter=@lightfast/www'",
     "ui:add": "pnpm --filter=@lightfast/ui ui:add",
     "ui:diff": "pnpm --filter=@lightfast/ui ui:diff",
-    "env:sync": "pnpm --filter=@lightfast/www env:sync",
-    "env:check": "cd apps/www && pnpm exec convex env list"
+    "env:sync": "tsx scripts/sync-env.ts",
+    "env:check": "pnpm exec convex env list",
+    "convex:dev": "pnpm exec convex dev"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,8 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@turbo/gen": "^2.5.0",
+    "convex": "^1.24.8",
+    "tsx": "^4.20.3",
     "turbo": "^2.5.4",
     "typescript": "^5.8.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@turbo/gen':
         specifier: ^2.5.0
         version: 2.5.4(@types/node@24.0.3)(typescript@5.8.3)
+      convex:
+        specifier: ^1.24.8
+        version: 1.24.8(react@19.1.0)
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       turbo:
         specifier: ^2.5.4
         version: 2.5.4

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -133,9 +133,9 @@ if command -v npx > /dev/null 2>&1; then
     if [ -d "$WORKTREE_PATH/apps/www/convex" ]; then
         log_info "Convex configuration found, syncing environment variables..."
         
-        # Run the environment sync script from apps/www
+        # Run the environment sync script (auto-detects .env.local location)
         if [ -f "$PROJECT_ROOT/scripts/sync-env.ts" ]; then
-            cd "$WORKTREE_PATH/apps/www" && pnpm run env:sync
+            cd "$WORKTREE_PATH" && pnpm run env:sync
             log_success "Environment variables synced to Convex"
         elif [ -f "$PROJECT_ROOT/scripts/sync-env.sh" ]; then
             bash "$PROJECT_ROOT/scripts/sync-env.sh"

--- a/scripts/sync-env.ts
+++ b/scripts/sync-env.ts
@@ -310,8 +310,6 @@ function findEnvFile(): string {
     path.resolve(process.cwd(), "..", ENV_FILE),
     // Two levels up (if running from nested subdirectory)
     path.resolve(process.cwd(), "..", "..", ENV_FILE),
-    // apps/www directory (fallback for compatibility)
-    path.resolve(process.cwd(), "apps", "www", ENV_FILE),
   ]
 
   for (const envPath of possiblePaths) {
@@ -338,9 +336,8 @@ async function syncEnvironment(): Promise<void> {
     if (!envPath) {
       log.error(`${ENV_FILE} file not found in any of the expected locations`)
       console.log("Expected locations:")
-      console.log("  - Current directory")
-      console.log("  - apps/www directory (if running from root)")
-      console.log("  - Parent directory (if running from apps/www)")
+      console.log("  - Current directory (root)")
+      console.log("  - Parent directory (if running from subdirectory)")
       console.log("")
       console.log(`Create ${ENV_FILE} with your environment variables`)
       console.log("Example:")

--- a/scripts/sync-env.ts
+++ b/scripts/sync-env.ts
@@ -207,7 +207,7 @@ async function syncVar(
         const escapedValue = JSON.stringify(value)
         execSync(`npx convex env set ${varName} ${escapedValue}`, {
           stdio: ["inherit", "pipe", "pipe"],
-          encoding: "utf8",
+          encoding: "utf8"
         })
       }
       log.success(`Synced ${varName}`)
@@ -304,14 +304,14 @@ function validateEnvironmentVariables(envVars: Record<string, string>): {
  */
 function findEnvFile(): string {
   const possiblePaths = [
-    // Current working directory
+    // Current working directory (root)
     path.resolve(process.cwd(), ENV_FILE),
-    // apps/www directory (if running from root)
-    path.resolve(process.cwd(), "apps", "www", ENV_FILE),
-    // Parent directory (if running from apps/www)
+    // Parent directory (if running from subdirectory)
     path.resolve(process.cwd(), "..", ENV_FILE),
-    // Two levels up (if running from apps/www/convex)
+    // Two levels up (if running from nested subdirectory)
     path.resolve(process.cwd(), "..", "..", ENV_FILE),
+    // apps/www directory (fallback for compatibility)
+    path.resolve(process.cwd(), "apps", "www", ENV_FILE),
   ]
 
   for (const envPath of possiblePaths) {


### PR DESCRIPTION
## Summary
- Centralizes env:sync script execution to root package.json using tsx directly
- Removes env:sync from apps/www/package.json to eliminate relative path issues  
- Simplifies monorepo structure by keeping environment operations at root level

## Changes
- Move env:sync to root package.json with direct tsx execution
- Add convex and tsx as root devDependencies
- Update convex:dev and env:check to run from root
- Update all documentation to clarify env:sync runs from root
- Fix sync-env.ts to work correctly from root directory
- Add /convex/ to root .gitignore

## Benefits
- Cleaner architecture with no `tsx ../../` relative paths
- Aligns with Vercel's expectation of root-level environment files
- Simplifies developer experience with consistent root-level commands

## Testing
- [x] env:sync runs successfully from root
- [x] convex:dev runs from root
- [x] Documentation updated across all files