### PR TITLE
feat: combine consecutive text parts on message completion

### DIFF
--- a/apps/www/convex/messages.ts
+++ b/apps/www/convex/messages.ts
@@ -12,6 +12,7 @@ import {
 	type CoreMessage,
 	type TextStreamPart,
 	type ToolSet,
+	smoothStream,
 	stepCountIs,
 	streamText,
 } from "ai";
@@ -744,12 +745,29 @@ export const completeStreamingMessage = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		// Verify the message exists
-		await getOrThrow(ctx.db, "messages", args.messageId);
+		// Verify the message exists and get current parts
+		const message = await getOrThrow(ctx.db, "messages", args.messageId);
 
-		// Update the message with completion status and full text
+		// Combine consecutive text parts to reduce storage
+		const currentParts = message.parts || [];
+		const combinedParts: typeof currentParts = [];
+
+		for (const part of currentParts) {
+			const lastPart = combinedParts[combinedParts.length - 1];
+
+			// If current part is text and last part is also text, combine them
+			if (part.type === "text" && lastPart?.type === "text") {
+				lastPart.text += part.text;
+			} else {
+				// Otherwise, add the part as is
+				combinedParts.push(part);
+			}
+		}
+
+		// Update the message with completion status, full text, and combined parts
 		await ctx.db.patch(args.messageId, {
 			body: args.fullText,
+			parts: combinedParts,
 			isStreaming: false,
 			isComplete: true,
 			thinkingCompletedAt: Date.now(),

--- a/apps/www/convex/messages.ts
+++ b/apps/www/convex/messages.ts
@@ -12,7 +12,6 @@ import {
 	type CoreMessage,
 	type TextStreamPart,
 	type ToolSet,
-	smoothStream,
 	stepCountIs,
 	streamText,
 } from "ai";
@@ -1552,7 +1551,7 @@ export const generateAIResponseWithMessage = internalAction({
 						break;
 
 					// Handle unknown part types (should never happen with proper AI SDK types)
-					default:
+					default: {
 						// This should be unreachable with proper TextStreamPart typing
 						const _exhaustiveCheck: never = part;
 						console.warn(
@@ -1561,6 +1560,7 @@ export const generateAIResponseWithMessage = internalAction({
 							_exhaustiveCheck,
 						);
 						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary
Combines consecutive text parts after message generation is complete to reduce database storage usage.

## Implementation
Modified the `completeStreamingMessage` mutation to merge consecutive text parts when a message is marked as complete. This approach:

- **Preserves real-time streaming**: Text parts are still saved individually during streaming for smooth UX
- **Combines on completion**: When streaming finishes, consecutive text parts are merged into single parts
- **Reduces storage**: Fewer parts in the database means less storage usage
- **No batching/flushing complexity**: Simple post-processing approach as requested

## Changes
- Updated `completeStreamingMessage` in `apps/www/convex/messages.ts`
- Added logic to iterate through parts and combine consecutive text parts
- Other part types (tool calls, reasoning, etc.) remain unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)