### PR TITLE
fix: resolve sidebar toggle not working on first keypress after page reload

### DIFF
--- a/apps/www/src/components/providers/keyboard-shortcuts-provider.tsx
+++ b/apps/www/src/components/providers/keyboard-shortcuts-provider.tsx
@@ -44,21 +44,8 @@ export function KeyboardShortcutsProvider({
 		},
 	});
 
-	// Add keyboard shortcut for sidebar toggle (Cmd/Ctrl+B)
-	useKeyboardShortcut({
-		key: "b",
-		ctrlKey: true,
-		metaKey: true,
-		callback: () => {
-			// Toggle sidebar - this is handled by the sidebar component itself
-			const event = new KeyboardEvent("keydown", {
-				key: "b",
-				ctrlKey: true,
-				metaKey: true,
-			});
-			window.dispatchEvent(event);
-		},
-	});
+	// Note: Sidebar toggle (Cmd/Ctrl+B) is handled directly by SidebarProvider
+	// to avoid circular event dispatch patterns that can fail after page reload
 
 	// Add keyboard shortcut for model selector (Cmd/Ctrl+.)
 	useKeyboardShortcut({


### PR DESCRIPTION
Closes #256

## Summary
Fixed the bug where the first cmd+b keypress after page reload didn't toggle the sidebar.

## Root Cause
The issue was caused by a circular keyboard event handling pattern:
1. **KeyboardShortcutsProvider** listened for real cmd+b events
2. It then created and dispatched synthetic KeyboardEvents to window
3. **SidebarProvider** was supposed to catch these synthetic events
4. After page reload, timing issues caused this pattern to fail

## Solution
Removed the circular event dispatch pattern. The SidebarProvider now handles cmd+b directly without needing synthetic events from KeyboardShortcutsProvider.

## Files Changed
- `apps/www/src/components/providers/keyboard-shortcuts-provider.tsx`: Removed synthetic event dispatch for sidebar toggle

## Testing
- ✅ Build passes
- ✅ Sidebar toggle now works immediately after page reload
- ✅ All other keyboard shortcuts continue to work
- ✅ No regression in sidebar functionality

🤖 Generated with [Claude Code](https://claude.ai/code)