### PR TITLE
feat: improve chat input focus and disable syntax highlighting for user messages

### DIFF
--- a/apps/www/src/components/chat/chat-input.tsx
+++ b/apps/www/src/components/chat/chat-input.tsx
@@ -372,6 +372,8 @@ const ChatInputComponent = ({
 			sessionStorage.setItem("selectedModelId", value);
 		}
 		setDropdownOpen(false);
+		// Focus the chat input after model selection
+		textareaRef.current?.focus();
 	}, []);
 
 	const toggleModelSelector = useCallback(() => {

--- a/apps/www/src/components/chat/shared/message-item.tsx
+++ b/apps/www/src/components/chat/shared/message-item.tsx
@@ -103,7 +103,12 @@ export function MessageItem({
 										case "text":
 											return (
 												<div key={partKey}>
-													<Markdown className="text-sm">{part.text}</Markdown>
+													<Markdown
+														className="text-sm"
+														disableHighlighting={!isAssistant}
+													>
+														{part.text}
+													</Markdown>
 													{isStreaming &&
 														!isComplete &&
 														index === displayParts.length - 1 && (
@@ -123,7 +128,12 @@ export function MessageItem({
 						// Legacy text rendering for messages without parts
 						return displayText ? (
 							<>
-								<Markdown className="text-sm">{displayText}</Markdown>
+								<Markdown
+									className="text-sm"
+									disableHighlighting={!isAssistant}
+								>
+									{displayText}
+								</Markdown>
 								{isStreaming && !isComplete && (
 									<span className="inline-block w-2 h-4 bg-current animate-pulse ml-1 opacity-70" />
 								)}


### PR DESCRIPTION
## Summary

This PR improves the chat interface by:
- Adding focus behavior to chat input after model selection for better UX
- Disabling Shiki syntax highlighting for user messages while keeping it for assistant messages

## Changes

### 1. Focus Behavior Enhancement
- **File**: apps/www/src/components/chat/chat-input.tsx
- **Change**: Added textareaRef.current?.focus() in handleModelChange callback
- **Benefit**: When users select a model from the dropdown, the chat input automatically gets focused, allowing them to start typing immediately

### 2. Conditional Syntax Highlighting
- **Files**: 
  - packages/ui/src/components/ui/markdown.tsx
  - packages/ui/src/components/ui/code-block.tsx 
  - apps/www/src/components/chat/shared/message-item.tsx
- **Changes**: 
  - Added disableHighlighting prop to Markdown and CodeBlock components
  - Modified CodeBlock to skip Shiki processing when highlighting is disabled
  - Updated MessageItem to pass disableHighlighting={\!isAssistant} to disable highlighting for user messages
- **Benefit**: User messages now display with plain code blocks (no syntax highlighting) while assistant messages retain full Shiki syntax highlighting

## Testing

- ✅ Build passes (SKIP_ENV_VALIDATION=true pnpm run build)
- ✅ Code formatted with Biome
- ✅ Changes are backward compatible
- ✅ No breaking changes to existing functionality

## Technical Details

The implementation uses a clean prop-drilling approach:
1. MessageItem determines if message is from assistant using message.messageType === 'assistant'
2. Markdown component receives disableHighlighting={\!isAssistant} prop
3. CodeBlock conditionally skips Shiki highlighting and returns plain pre/code when disabled
4. Maintains all existing functionality for copy buttons, language labels, etc.

🤖 Generated with [Claude Code](https://claude.ai/code)