### PR TITLE
fix: update package imports from @repo/ui to @lightfast/ui in docs app

### DIFF
--- a/apps/docs/biome.json
+++ b/apps/docs/biome.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["../../biome.json"]
+	"extends": ["../../biome.json"]
 }

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -1,12 +1,12 @@
-import { createMDX } from "fumadocs-mdx/next"
-import type { NextConfig } from "next/types"
+import { createMDX } from "fumadocs-mdx/next";
+import type { NextConfig } from "next/types";
 
-const withMDX = createMDX()
+const withMDX = createMDX();
 
 const config: NextConfig = {
-  reactStrictMode: true,
-  basePath: "/docs",
-  assetPrefix: "/docs",
-}
+	reactStrictMode: true,
+	basePath: "/docs",
+	assetPrefix: "/docs",
+};
 
-export default withMDX(config)
+export default withMDX(config);

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "@lightfast/docs",
-  "version": "1.0.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev --port 3002 --turbo",
-    "build": "next build",
-    "start": "next start",
-    "lint": "biome check --write .",
-    "format": "biome format --write .",
-    "typecheck": "tsc --noEmit",
-    "clean": "rm -rf .next .turbo dist .source tsconfig.tsbuildinfo",
-    "postinstall": "fumadocs-mdx"
-  },
-  "dependencies": {
-    "clsx": "^2.1.1",
-    "@lightfast/ui": "workspace:*",
-    "fumadocs-core": "^15.3.4",
-    "fumadocs-mdx": "^11.6.5",
-    "fumadocs-ui": "^15.3.4",
-    "geist": "^1.4.2",
-    "lucide-react": "^0.468.0",
-    "next": "^15.2.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.10"
-  },
-  "devDependencies": {
-    "@repo/biome": "workspace:*",
-    "@repo/typescript": "workspace:*",
-    "@tailwindcss/postcss": "^4.1.10",
-    "@types/mdx": "^2.0.13",
-    "@types/node": "^24.0.0",
-    "@types/react": "^19.1.7",
-    "@types/react-dom": "^19.1.6",
-    "autoprefixer": "^10.4.20",
-    "postcss": "^8.5.5",
-    "typescript": "^5.8.3"
-  }
+	"name": "@lightfast/docs",
+	"version": "1.0.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev --port 3002 --turbo",
+		"build": "next build",
+		"start": "next start",
+		"lint": "biome check --write .",
+		"format": "biome format --write .",
+		"typecheck": "tsc --noEmit",
+		"clean": "rm -rf .next .turbo dist .source tsconfig.tsbuildinfo",
+		"postinstall": "fumadocs-mdx"
+	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"@lightfast/ui": "workspace:*",
+		"fumadocs-core": "^15.3.4",
+		"fumadocs-mdx": "^11.6.5",
+		"fumadocs-ui": "^15.3.4",
+		"geist": "^1.4.2",
+		"lucide-react": "^0.468.0",
+		"next": "^15.2.1",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"tailwind-merge": "^3.3.1",
+		"tailwindcss": "^4.1.10"
+	},
+	"devDependencies": {
+		"@repo/biome": "workspace:*",
+		"@repo/typescript": "workspace:*",
+		"@tailwindcss/postcss": "^4.1.10",
+		"@types/mdx": "^2.0.13",
+		"@types/node": "^24.0.0",
+		"@types/react": "^19.1.7",
+		"@types/react-dom": "^19.1.6",
+		"autoprefixer": "^10.4.20",
+		"postcss": "^8.5.5",
+		"typescript": "^5.8.3"
+	}
 }

--- a/apps/docs/postcss.config.mjs
+++ b/apps/docs/postcss.config.mjs
@@ -1,1 +1,1 @@
-export { default } from "@repo/ui/postcss.config";
+export { default } from "@lightfast/ui/postcss.config";

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig, defineDocs } from "fumadocs-mdx/config"
+import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 
 export const { docs, meta } = defineDocs({
-  dir: "src/content/docs",
-})
+	dir: "src/content/docs",
+});
 
-export default defineConfig()
+export default defineConfig();

--- a/apps/docs/src/app/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/[[...slug]]/page.tsx
@@ -1,58 +1,58 @@
-import { getPage, getPages } from "@/src/lib/source"
-import defaultMdxComponents from "fumadocs-ui/mdx"
-import { DocsBody, DocsPage } from "fumadocs-ui/page"
-import type { Metadata } from "next"
-import { notFound } from "next/navigation"
+import { getPage, getPages } from "@/src/lib/source";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { DocsBody, DocsPage } from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 export default async function Page({
-  params,
+	params,
 }: {
-  params: Promise<{ slug?: string[] }>
+	params: Promise<{ slug?: string[] }>;
 }) {
-  const resolvedParams = await params
-  const page = getPage(resolvedParams.slug)
+	const resolvedParams = await params;
+	const page = getPage(resolvedParams.slug);
 
-  if (page == null) {
-    notFound()
-  }
+	if (page == null) {
+		notFound();
+	}
 
-  const MDX = page.data.body
+	const MDX = page.data.body;
 
-  return (
-    <DocsPage toc={page.data.toc}>
-      <DocsBody>
-        <h1>{page.data.title}</h1>
-        <MDX components={{ ...defaultMdxComponents }} />
-      </DocsBody>
-    </DocsPage>
-  )
+	return (
+		<DocsPage toc={page.data.toc}>
+			<DocsBody>
+				<h1>{page.data.title}</h1>
+				<MDX components={{ ...defaultMdxComponents }} />
+			</DocsBody>
+		</DocsPage>
+	);
 }
 
 export async function generateStaticParams() {
-  return getPages().map((page) => ({
-    slug: page.slugs,
-  }))
+	return getPages().map((page) => ({
+		slug: page.slugs,
+	}));
 }
 
 export async function generateMetadata({
-  params,
+	params,
 }: { params: Promise<{ slug?: string[] }> }): Promise<Metadata> {
-  const resolvedParams = await params
-  const page = getPage(resolvedParams.slug)
+	const resolvedParams = await params;
+	const page = getPage(resolvedParams.slug);
 
-  if (page == null) notFound()
+	if (page == null) notFound();
 
-  return {
-    title: page.data.title,
-    description: page.data.description,
-    openGraph: {
-      title: page.data.title,
-      description: page.data.description,
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: page.data.title,
-      description: page.data.description,
-    },
-  }
+	return {
+		title: page.data.title,
+		description: page.data.description,
+		openGraph: {
+			title: page.data.title,
+			description: page.data.description,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: page.data.title,
+			description: page.data.description,
+		},
+	};
 }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,73 +1,73 @@
-import "./globals.css"
-import { docsMetadata, siteConfig } from "@/src/lib/site-config"
-import { fonts } from "@repo/ui/lib/fonts"
-import { RootProvider } from "fumadocs-ui/provider"
-import type { Metadata } from "next"
-import type { ReactNode } from "react"
-import { DocsLayoutWrapper } from "../components/docs-layout-wrapper"
+import "./globals.css";
+import { docsMetadata, siteConfig } from "@/src/lib/site-config";
+import { fonts } from "@lightfast/ui/lib/fonts";
+import { RootProvider } from "fumadocs-ui/provider";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { DocsLayoutWrapper } from "../components/docs-layout-wrapper";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en" className={fonts} suppressHydrationWarning>
-      <body className="min-h-screen bg-background text-foreground antialiased">
-        <RootProvider>
-          <DocsLayoutWrapper>{children}</DocsLayoutWrapper>
-        </RootProvider>
-      </body>
-    </html>
-  )
+	return (
+		<html lang="en" className={fonts} suppressHydrationWarning>
+			<body className="min-h-screen bg-background text-foreground antialiased">
+				<RootProvider>
+					<DocsLayoutWrapper>{children}</DocsLayoutWrapper>
+				</RootProvider>
+			</body>
+		</html>
+	);
 }
 
 export const metadata: Metadata = {
-  title: {
-    default: siteConfig.name,
-    template: `%s | ${siteConfig.name}`,
-  },
-  description: siteConfig.description,
-  keywords: [...docsMetadata.keywords],
-  authors: [...docsMetadata.authors],
-  creator: docsMetadata.creator,
-  metadataBase: new URL(siteConfig.url),
-  openGraph: {
-    type: "website",
-    locale: "en_US",
-    url: siteConfig.url,
-    title: siteConfig.name,
-    description: siteConfig.description,
-    siteName: siteConfig.name,
-    images: [
-      {
-        url: siteConfig.ogImage,
-        width: 1200,
-        height: 630,
-        alt: siteConfig.name,
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: siteConfig.name,
-    description: siteConfig.description,
-    images: [siteConfig.ogImage],
-    creator: "@lightfastai",
-  },
-  icons: {
-    icon: "/favicon.ico",
-    shortcut: "/favicon-16x16.png",
-    apple: "/apple-touch-icon.png",
-    other: [
-      {
-        rel: "icon",
-        url: "/favicon-32x32.png",
-      },
-      {
-        rel: "icon",
-        url: "/android-chrome-192x192.png",
-      },
-      {
-        rel: "icon",
-        url: "/android-chrome-512x512.png",
-      },
-    ],
-  },
-}
+	title: {
+		default: siteConfig.name,
+		template: `%s | ${siteConfig.name}`,
+	},
+	description: siteConfig.description,
+	keywords: [...docsMetadata.keywords],
+	authors: [...docsMetadata.authors],
+	creator: docsMetadata.creator,
+	metadataBase: new URL(siteConfig.url),
+	openGraph: {
+		type: "website",
+		locale: "en_US",
+		url: siteConfig.url,
+		title: siteConfig.name,
+		description: siteConfig.description,
+		siteName: siteConfig.name,
+		images: [
+			{
+				url: siteConfig.ogImage,
+				width: 1200,
+				height: 630,
+				alt: siteConfig.name,
+			},
+		],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: siteConfig.name,
+		description: siteConfig.description,
+		images: [siteConfig.ogImage],
+		creator: "@lightfastai",
+	},
+	icons: {
+		icon: "/favicon.ico",
+		shortcut: "/favicon-16x16.png",
+		apple: "/apple-touch-icon.png",
+		other: [
+			{
+				rel: "icon",
+				url: "/favicon-32x32.png",
+			},
+			{
+				rel: "icon",
+				url: "/android-chrome-192x192.png",
+			},
+			{
+				rel: "icon",
+				url: "/android-chrome-512x512.png",
+			},
+		],
+	},
+};

--- a/apps/docs/src/app/not-found.tsx
+++ b/apps/docs/src/app/not-found.tsx
@@ -1,20 +1,20 @@
-import Link from "next/link"
+import Link from "next/link";
 
 export default function NotFound() {
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="text-center">
-        <h2 className="text-2xl font-bold">Page Not Found</h2>
-        <p className="mt-2 text-muted-foreground">
-          The documentation page you're looking for doesn't exist.
-        </p>
-        <Link
-          href="/docs"
-          className="mt-4 inline-block text-primary underline-offset-4 hover:underline"
-        >
-          Return to docs home
-        </Link>
-      </div>
-    </div>
-  )
+	return (
+		<div className="flex min-h-screen items-center justify-center">
+			<div className="text-center">
+				<h2 className="text-2xl font-bold">Page Not Found</h2>
+				<p className="mt-2 text-muted-foreground">
+					The documentation page you're looking for doesn't exist.
+				</p>
+				<Link
+					href="/docs"
+					className="mt-4 inline-block text-primary underline-offset-4 hover:underline"
+				>
+					Return to docs home
+				</Link>
+			</div>
+		</div>
+	);
 }

--- a/apps/docs/src/components/docs-layout-config.tsx
+++ b/apps/docs/src/components/docs-layout-config.tsx
@@ -1,42 +1,42 @@
-import { siteConfig } from "@/src/lib/site-config"
-import { Icons } from "@repo/ui/components/ui/icons"
-import type { PageTree } from "fumadocs-core/server"
-import type { DocsLayoutProps } from "fumadocs-ui/layouts/docs"
-import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared"
+import { siteConfig } from "@/src/lib/site-config";
+import { Icons } from "@lightfast/ui/components/ui/icons";
+import type { PageTree } from "fumadocs-core/server";
+import type { DocsLayoutProps } from "fumadocs-ui/layouts/docs";
+import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 
 export const baseOptions: BaseLayoutProps = {
-  nav: {
-    title: <Icons.logo className="text-white w-6 h-max border" />,
-    url: siteConfig.links.chat.href,
-  },
-  links: [
-    {
-      text: siteConfig.links.github.title,
-      url: siteConfig.links.github.href,
-      icon: <Icons.gitHub className="size-4" />,
-      external: siteConfig.links.github.external,
-    },
-    {
-      text: siteConfig.links.twitter.title,
-      url: siteConfig.links.twitter.href,
-      icon: <Icons.twitter className="size-3" />,
-      external: siteConfig.links.twitter.external,
-    },
-    {
-      text: siteConfig.links.discord.title,
-      url: siteConfig.links.discord.href,
-      icon: <Icons.discord className="size-4" />,
-      external: siteConfig.links.discord.external,
-    },
-  ],
-  themeSwitch: {
-    enabled: false,
-    mode: "light-dark-system",
-  },
-}
+	nav: {
+		title: <Icons.logo className="text-white w-6 h-max border" />,
+		url: siteConfig.links.chat.href,
+	},
+	links: [
+		{
+			text: siteConfig.links.github.title,
+			url: siteConfig.links.github.href,
+			icon: <Icons.gitHub className="size-4" />,
+			external: siteConfig.links.github.external,
+		},
+		{
+			text: siteConfig.links.twitter.title,
+			url: siteConfig.links.twitter.href,
+			icon: <Icons.twitter className="size-3" />,
+			external: siteConfig.links.twitter.external,
+		},
+		{
+			text: siteConfig.links.discord.title,
+			url: siteConfig.links.discord.href,
+			icon: <Icons.discord className="size-4" />,
+			external: siteConfig.links.discord.external,
+		},
+	],
+	themeSwitch: {
+		enabled: false,
+		mode: "light-dark-system",
+	},
+};
 
 // We'll add the tree property in the layout file using the source object
 export const createDocsOptions = (tree: PageTree.Root): DocsLayoutProps => ({
-  ...baseOptions,
-  tree, // Add tree from source
-})
+	...baseOptions,
+	tree, // Add tree from source
+});

--- a/apps/docs/src/components/docs-layout-wrapper.tsx
+++ b/apps/docs/src/components/docs-layout-wrapper.tsx
@@ -1,21 +1,21 @@
-import { DocsLayout } from "fumadocs-ui/layouts/docs"
-import type { ReactNode } from "react"
-import { source } from "../lib/source"
-import { createDocsOptions } from "./docs-layout-config"
-import { SiteHeader } from "./site-header"
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import type { ReactNode } from "react";
+import { source } from "../lib/source";
+import { createDocsOptions } from "./docs-layout-config";
+import { SiteHeader } from "./site-header";
 
 export function DocsLayoutWrapper({ children }: { children: ReactNode }) {
-  // Create the docs options with the page tree from source
-  const docsOptions = createDocsOptions(source.pageTree)
+	// Create the docs options with the page tree from source
+	const docsOptions = createDocsOptions(source.pageTree);
 
-  return (
-    <>
-      <DocsLayout {...docsOptions}>
-        <div className="flex flex-col w-full">
-          <SiteHeader />
-          <div className="flex flex-row w-full">{children}</div>
-        </div>
-      </DocsLayout>
-    </>
-  )
+	return (
+		<>
+			<DocsLayout {...docsOptions}>
+				<div className="flex flex-col w-full">
+					<SiteHeader />
+					<div className="flex flex-row w-full">{children}</div>
+				</div>
+			</DocsLayout>
+		</>
+	);
 }

--- a/apps/docs/src/components/site-header.tsx
+++ b/apps/docs/src/components/site-header.tsx
@@ -1,52 +1,52 @@
-import { siteConfig } from "@/src/lib/site-config"
-import { Icons } from "@repo/ui/components/ui/icons"
-import Link from "next/link"
+import { siteConfig } from "@/src/lib/site-config";
+import { Icons } from "@lightfast/ui/components/ui/icons";
+import Link from "next/link";
 
 export function SiteHeader() {
-  return (
-    <div className="w-full flex justify-between items-center py-3 px-6 border-b">
-      <div className="flex-1">
-        {/* Left side - could add logo or title here */}
-      </div>
-      <div className="flex items-center gap-6">
-        <Link
-          href={siteConfig.links.github.href}
-          target={siteConfig.links.github.external ? "_blank" : undefined}
-          rel={
-            siteConfig.links.github.external ? "noopener noreferrer" : undefined
-          }
-          aria-label={siteConfig.links.github.title}
-          className="transition-transform duration-200 hover:scale-110"
-        >
-          <Icons.gitHub className="size-4" />
-        </Link>
-        <Link
-          href={siteConfig.links.twitter.href}
-          target={siteConfig.links.twitter.external ? "_blank" : undefined}
-          rel={
-            siteConfig.links.twitter.external
-              ? "noopener noreferrer"
-              : undefined
-          }
-          aria-label={siteConfig.links.twitter.title}
-          className="transition-transform duration-200 hover:scale-110"
-        >
-          <Icons.twitter className="size-3" />
-        </Link>
-        <Link
-          href={siteConfig.links.discord.href}
-          target={siteConfig.links.discord.external ? "_blank" : undefined}
-          rel={
-            siteConfig.links.discord.external
-              ? "noopener noreferrer"
-              : undefined
-          }
-          aria-label={siteConfig.links.discord.title}
-          className="transition-transform duration-200 hover:scale-110"
-        >
-          <Icons.discord className="size-4" />
-        </Link>
-      </div>
-    </div>
-  )
+	return (
+		<div className="w-full flex justify-between items-center py-3 px-6 border-b">
+			<div className="flex-1">
+				{/* Left side - could add logo or title here */}
+			</div>
+			<div className="flex items-center gap-6">
+				<Link
+					href={siteConfig.links.github.href}
+					target={siteConfig.links.github.external ? "_blank" : undefined}
+					rel={
+						siteConfig.links.github.external ? "noopener noreferrer" : undefined
+					}
+					aria-label={siteConfig.links.github.title}
+					className="transition-transform duration-200 hover:scale-110"
+				>
+					<Icons.gitHub className="size-4" />
+				</Link>
+				<Link
+					href={siteConfig.links.twitter.href}
+					target={siteConfig.links.twitter.external ? "_blank" : undefined}
+					rel={
+						siteConfig.links.twitter.external
+							? "noopener noreferrer"
+							: undefined
+					}
+					aria-label={siteConfig.links.twitter.title}
+					className="transition-transform duration-200 hover:scale-110"
+				>
+					<Icons.twitter className="size-3" />
+				</Link>
+				<Link
+					href={siteConfig.links.discord.href}
+					target={siteConfig.links.discord.external ? "_blank" : undefined}
+					rel={
+						siteConfig.links.discord.external
+							? "noopener noreferrer"
+							: undefined
+					}
+					aria-label={siteConfig.links.discord.title}
+					className="transition-transform duration-200 hover:scale-110"
+				>
+					<Icons.discord className="size-4" />
+				</Link>
+			</div>
+		</div>
+	);
 }

--- a/apps/docs/src/content/docs/architecture/meta.json
+++ b/apps/docs/src/content/docs/architecture/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Architecture",
-  "pages": ["overview", "tech-stack", "convex"]
+	"title": "Architecture",
+	"pages": ["overview", "tech-stack", "convex"]
 }

--- a/apps/docs/src/content/docs/development/meta.json
+++ b/apps/docs/src/content/docs/development/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Development",
-  "pages": ["setup"]
+	"title": "Development",
+	"pages": ["setup"]
 }

--- a/apps/docs/src/content/docs/features/meta.json
+++ b/apps/docs/src/content/docs/features/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Features",
-  "pages": ["chat", "models"]
+	"title": "Features",
+	"pages": ["chat", "models"]
 }

--- a/apps/docs/src/content/docs/getting-started/meta.json
+++ b/apps/docs/src/content/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Getting Started",
-  "pages": ["installation", "quickstart", "configuration"]
+	"title": "Getting Started",
+	"pages": ["installation", "quickstart", "configuration"]
 }

--- a/apps/docs/src/content/docs/guides/meta.json
+++ b/apps/docs/src/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Guides",
-  "pages": ["claude-code-workflow", "deployment", "self-hosting"]
+	"title": "Guides",
+	"pages": ["claude-code-workflow", "deployment", "self-hosting"]
 }

--- a/apps/docs/src/content/docs/meta.json
+++ b/apps/docs/src/content/docs/meta.json
@@ -1,13 +1,13 @@
 {
-  "title": "Documentation",
-  "pages": [
-    "overview",
-    "getting-started",
-    "guides",
-    "development",
-    "architecture",
-    "features",
-    "reference",
-    "resources"
-  ]
+	"title": "Documentation",
+	"pages": [
+		"overview",
+		"getting-started",
+		"guides",
+		"development",
+		"architecture",
+		"features",
+		"reference",
+		"resources"
+	]
 }

--- a/apps/docs/src/content/docs/overview/meta.json
+++ b/apps/docs/src/content/docs/overview/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Overview",
-  "pages": ["index", "introduction", "features"]
+	"title": "Overview",
+	"pages": ["index", "introduction", "features"]
 }

--- a/apps/docs/src/content/docs/reference/meta.json
+++ b/apps/docs/src/content/docs/reference/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Reference",
-  "pages": ["api", "models", "configuration-reference"]
+	"title": "Reference",
+	"pages": ["api", "models", "configuration-reference"]
 }

--- a/apps/docs/src/content/docs/resources/meta.json
+++ b/apps/docs/src/content/docs/resources/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Resources",
-  "pages": ["troubleshooting", "migration", "changelog"]
+	"title": "Resources",
+	"pages": ["troubleshooting", "migration", "changelog"]
 }

--- a/apps/docs/src/lib/site-config.ts
+++ b/apps/docs/src/lib/site-config.ts
@@ -1,65 +1,65 @@
-import type { SiteConfig } from "@repo/ui/types/site"
+import type { SiteConfig } from "@lightfast/ui/types/site";
 
-type SiteLinks = "twitter" | "github" | "discord" | "chat" | "home"
+type SiteLinks = "twitter" | "github" | "discord" | "chat" | "home";
 
 export const siteConfig: SiteConfig<SiteLinks> = {
-  name: "Lightfast Docs",
-  url: "https://chat.lightfast.ai",
-  ogImage: "https://lightfast.ai/og.jpg",
-  description:
-    "Documentation for Lightfast Chat - Learn how to build and deploy real-time AI chat applications with Claude 4, GPT-4o, and streaming responses.",
-  links: {
-    twitter: {
-      title: "Twitter",
-      href: "https://x.com/lightfastai",
-      external: true,
-    },
-    github: {
-      title: "GitHub",
-      href: "https://github.com/lightfastai/chat",
-      external: true,
-    },
-    discord: {
-      title: "Discord",
-      href: "https://discord.gg/YqPDfcar2C",
-      external: true,
-    },
-    chat: {
-      title: "Chat App",
-      href: "https://chat.lightfast.ai",
-      external: true,
-    },
-    home: {
-      title: "Lightfast Home",
-      href: "https://lightfast.ai",
-      external: true,
-    },
-  },
-  location: "3141, Melbourne, VIC, Australia",
-}
+	name: "Lightfast Docs",
+	url: "https://chat.lightfast.ai",
+	ogImage: "https://lightfast.ai/og.jpg",
+	description:
+		"Documentation for Lightfast Chat - Learn how to build and deploy real-time AI chat applications with Claude 4, GPT-4o, and streaming responses.",
+	links: {
+		twitter: {
+			title: "Twitter",
+			href: "https://x.com/lightfastai",
+			external: true,
+		},
+		github: {
+			title: "GitHub",
+			href: "https://github.com/lightfastai/chat",
+			external: true,
+		},
+		discord: {
+			title: "Discord",
+			href: "https://discord.gg/YqPDfcar2C",
+			external: true,
+		},
+		chat: {
+			title: "Chat App",
+			href: "https://chat.lightfast.ai",
+			external: true,
+		},
+		home: {
+			title: "Lightfast Home",
+			href: "https://lightfast.ai",
+			external: true,
+		},
+	},
+	location: "3141, Melbourne, VIC, Australia",
+};
 
 // Export additional metadata for docs
 export const docsMetadata = {
-  keywords: [
-    "Lightfast documentation",
-    "AI chat docs",
-    "Claude 4 integration",
-    "GPT-4o integration",
-    "real-time chat tutorial",
-    "Convex database guide",
-    "Next.js chat documentation",
-    "AI assistant setup",
-    "streaming API docs",
-    "authentication guide",
-    "deployment guide",
-    "API reference",
-    "developer docs",
-  ],
-  authors: [
-    {
-      name: "Lightfast",
-      url: "https://lightfast.ai",
-    },
-  ],
-  creator: "Lightfast",
-} as const
+	keywords: [
+		"Lightfast documentation",
+		"AI chat docs",
+		"Claude 4 integration",
+		"GPT-4o integration",
+		"real-time chat tutorial",
+		"Convex database guide",
+		"Next.js chat documentation",
+		"AI assistant setup",
+		"streaming API docs",
+		"authentication guide",
+		"deployment guide",
+		"API reference",
+		"developer docs",
+	],
+	authors: [
+		{
+			name: "Lightfast",
+			url: "https://lightfast.ai",
+		},
+	],
+	creator: "Lightfast",
+} as const;

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,10 +1,10 @@
-import { docs, meta } from "@/.source"
-import { loader } from "fumadocs-core/source"
-import { createMDXSource } from "fumadocs-mdx"
+import { docs, meta } from "@/.source";
+import { loader } from "fumadocs-core/source";
+import { createMDXSource } from "fumadocs-mdx";
 
 export const source = loader({
-  baseUrl: "/",
-  source: createMDXSource(docs, meta),
-})
+	baseUrl: "/",
+	source: createMDXSource(docs, meta),
+});
 
-export const { getPage, getPages, pageTree } = source
+export const { getPage, getPages, pageTree } = source;

--- a/apps/docs/src/lib/utils.ts
+++ b/apps/docs/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+	return twMerge(clsx(inputs));
 }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,18 +1,18 @@
 {
-  "extends": "@repo/typescript/nextjs",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./*"]
-    },
-    "noUncheckedIndexedAccess": false
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".source/**/*"
-  ],
-  "exclude": ["node_modules", "tmp_repo"]
+	"extends": "@repo/typescript/nextjs",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["./*"]
+		},
+		"noUncheckedIndexedAccess": false
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".source/**/*"
+	],
+	"exclude": ["node_modules", "tmp_repo"]
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "turbo build",
-  "framework": "nextjs",
-  "outputDirectory": ".next"
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"buildCommand": "turbo build",
+	"framework": "nextjs",
+	"outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary
- Fixed incorrect package imports in docs app that were causing build failures
- Updated all imports from `@repo/ui` to `@lightfast/ui`

## Changes
- Updated 5 files with incorrect import paths:
  - `src/app/layout.tsx`
  - `src/components/site-header.tsx`
  - `src/components/docs-layout-config.tsx`
  - `src/lib/site-config.ts`
  - `postcss.config.mjs`

## Testing
- ✅ `pnpm run build:docs` - Build passes successfully
- ✅ `pnpm run format` - Code formatted correctly
- ✅ All imports now correctly reference the `@lightfast/ui` package

## Impact
This fixes the docs build errors that were preventing successful deployments.