### PR TITLE
fix: auto-scroll sidebar to top when new thread is created

### DIFF
--- a/apps/www/src/env.ts
+++ b/apps/www/src/env.ts
@@ -57,6 +57,10 @@ export const env = createEnv({
 		NEXT_PUBLIC_SENTRY_ENVIRONMENT: z
 			.enum(["development", "production"])
 			.default("development"),
+
+		// PostHog analytics configuration
+		NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+		NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
 	},
 	/*
 	 * Shared environment variables, available on both client and server.
@@ -91,6 +95,8 @@ export const env = createEnv({
 		NEXT_PUBLIC_VERCEL_ENV: process.env.NEXT_PUBLIC_VERCEL_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
 		NEXT_PUBLIC_SENTRY_ENVIRONMENT: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+		NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+		NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 		// Shared
 		NODE_ENV: process.env.NODE_ENV,
 	},

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-function ScrollArea({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+const ScrollArea = React.forwardRef<
+	React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => {
 	return (
 		<ScrollAreaPrimitive.Root
+			ref={ref}
 			data-slot="scroll-area"
 			className={cn("relative", className)}
 			{...props}
@@ -26,7 +26,8 @@ function ScrollArea({
 			<ScrollAreaPrimitive.Corner />
 		</ScrollAreaPrimitive.Root>
 	);
-}
+});
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 function ScrollBar({
 	className,


### PR DESCRIPTION
## Summary
- Fixes sidebar cutoff issue where newly created threads aren't visible
- Implements automatic scrolling to top when a new thread is detected
- Works for both virtualized and non-virtualized thread lists

## Problem
When users create a new chat, the sidebar doesn't automatically scroll to show the new thread at the top. This causes the new chat to be "cut off" or hidden from view, requiring manual scrolling to see it.

## Solution
Added logic to detect when a new thread is added to the beginning of the threads list and automatically scroll the sidebar to the top. The implementation:

1. Tracks previous threads using `useRef` to maintain state across renders
2. Compares thread IDs to detect when a new thread appears at position 0
3. Smoothly scrolls to top when a new thread is detected
4. Updates ScrollArea component to support forwardRef for DOM access

## Additional Changes
- Fixed missing PostHog environment variables that were causing build errors
- Fixed React key prop warning in virtualized threads list

## Testing
- Create a new chat and verify the sidebar scrolls to show it
- Test with multiple existing threads to ensure scrolling works correctly
- Verify smooth scrolling animation
- Test both with and without virtualization enabled

🤖 Generated with [Claude Code](https://claude.ai/code)