### PR TITLE
feat: add Haskell syntax highlighting support

### DIFF
--- a/packages/ui/src/components/ui/code-block.tsx
+++ b/packages/ui/src/components/ui/code-block.tsx
@@ -45,6 +45,7 @@ const getHighlighter = async (): Promise<Highlighter> => {
 				"php",
 				"ruby",
 				"xml",
+				"haskell",
 				"plaintext",
 			],
 		});
@@ -96,6 +97,7 @@ export function CodeBlock({ code, language = "", className }: CodeBlockProps) {
 			md: "markdown",
 			"c++": "cpp",
 			rs: "rust",
+			hs: "haskell",
 		};
 		return langMap[lang.toLowerCase()] || lang.toLowerCase();
 	};


### PR DESCRIPTION
## Summary
- Added Haskell language support to the code block syntax highlighter
- Users can now use ```haskell or ```hs code blocks with proper syntax highlighting

## Changes
- Added "haskell" to the supported languages array in Shiki configuration
- Added "hs" alias that maps to "haskell" for convenience

## Testing
To test this feature:
1. Create a chat message with a Haskell code block
2. Verify that the syntax highlighting is applied correctly

Example test code:
```haskell
-- Fibonacci sequence
fibonacci :: Int -> Int
fibonacci 0 = 0
fibonacci 1 = 1
fibonacci n = fibonacci (n-1) + fibonacci (n-2)

-- Main function
main :: IO ()
main = do
    putStrLn "Enter a number:"
    num <- readLn
    putStrLn $ "Fibonacci of " ++ show num ++ " is " ++ show (fibonacci num)
```

## Notes
- Shiki v3.7.0 already includes Haskell language support, so no additional dependencies were needed
- The change is minimal and only affects the code-block.tsx component in the UI package