### PR TITLE
feat: switch to VS Code Dark+ theme for syntax highlighting

### DIFF
--- a/packages/ui/src/components/ui/code-block.tsx
+++ b/packages/ui/src/components/ui/code-block.tsx
@@ -23,7 +23,7 @@ const getHighlighter = async (): Promise<Highlighter> => {
 
 	if (!highlighterPromise) {
 		highlighterPromise = createHighlighter({
-			themes: ["github-light", "github-dark"],
+			themes: ["light-plus", "dark-plus"],
 			langs: [
 				"javascript",
 				"typescript",
@@ -114,7 +114,7 @@ export function CodeBlock({ code, language = "", className }: CodeBlockProps) {
 
 				if (!isMounted) return;
 
-				const currentTheme = theme === "dark" ? "github-dark" : "github-light";
+				const currentTheme = theme === "dark" ? "dark-plus" : "light-plus";
 				const langToUse = normalizedLanguage || "plaintext";
 
 				try {


### PR DESCRIPTION
## Summary
- Switched from GitHub themes to VS Code's Dark+ and Light+ themes for code syntax highlighting
- Provides a more familiar and developer-friendly syntax highlighting experience

## Changes
- Updated `packages/ui/src/components/ui/code-block.tsx`:
  - Changed theme configuration from `["github-light", "github-dark"]` to `["light-plus", "dark-plus"]`
  - Updated theme selection logic to use `dark-plus` for dark mode and `light-plus` for light mode

## Why VS Code Themes?
- VS Code's Dark+ theme is one of the most popular and widely recognized syntax highlighting themes
- Many developers are already familiar with these themes from their daily coding
- The Dark+ theme provides excellent contrast and readability in dark mode
- The Light+ theme offers clear, clean highlighting for light mode users

## Testing
The new themes can be tested by:
1. Creating code blocks in chat messages
2. Toggling between light and dark modes to see both themes
3. Testing with various programming languages (JavaScript, Python, Haskell, etc.)

## Before & After
- **Before**: GitHub light/dark themes
- **After**: VS Code Light+/Dark+ themes