### PR TITLE
feat: remove ipHash and userAgent functionality from share access

### DIFF
--- a/apps/www/convex/_generated/api.d.ts
+++ b/apps/www/convex/_generated/api.d.ts
@@ -9,9 +9,9 @@
  */
 
 import type {
-  ApiFromModules,
-  FilterApi,
-  FunctionReference,
+	ApiFromModules,
+	FilterApi,
+	FunctionReference,
 } from "convex/server";
 import type * as auth from "../auth.js";
 import type * as env from "../env.js";
@@ -47,36 +47,36 @@ import type * as validators from "../validators.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
-  auth: typeof auth;
-  env: typeof env;
-  feedback: typeof feedback;
-  files: typeof files;
-  http: typeof http;
-  httpStreaming: typeof httpStreaming;
-  "lib/ai/client": typeof lib_ai_client;
-  "lib/ai/writer/message_part_writer": typeof lib_ai_writer_message_part_writer;
-  "lib/auth": typeof lib_auth;
-  "lib/capability_guards": typeof lib_capability_guards;
-  "lib/create_system_prompt": typeof lib_create_system_prompt;
-  "lib/database": typeof lib_database;
-  "lib/error_handling": typeof lib_error_handling;
-  "lib/errors": typeof lib_errors;
-  "lib/services/encryption": typeof lib_services_encryption;
-  messages: typeof messages;
-  setup: typeof setup;
-  share: typeof share;
-  threads: typeof threads;
-  titles: typeof titles;
-  types: typeof types;
-  userSettings: typeof userSettings;
-  users: typeof users;
-  validators: typeof validators;
+	auth: typeof auth;
+	env: typeof env;
+	feedback: typeof feedback;
+	files: typeof files;
+	http: typeof http;
+	httpStreaming: typeof httpStreaming;
+	"lib/ai/client": typeof lib_ai_client;
+	"lib/ai/writer/message_part_writer": typeof lib_ai_writer_message_part_writer;
+	"lib/auth": typeof lib_auth;
+	"lib/capability_guards": typeof lib_capability_guards;
+	"lib/create_system_prompt": typeof lib_create_system_prompt;
+	"lib/database": typeof lib_database;
+	"lib/error_handling": typeof lib_error_handling;
+	"lib/errors": typeof lib_errors;
+	"lib/services/encryption": typeof lib_services_encryption;
+	messages: typeof messages;
+	setup: typeof setup;
+	share: typeof share;
+	threads: typeof threads;
+	titles: typeof titles;
+	types: typeof types;
+	userSettings: typeof userSettings;
+	users: typeof users;
+	validators: typeof validators;
 }>;
 export declare const api: FilterApi<
-  typeof fullApi,
-  FunctionReference<any, "public">
+	typeof fullApi,
+	FunctionReference<any, "public">
 >;
 export declare const internal: FilterApi<
-  typeof fullApi,
-  FunctionReference<any, "internal">
+	typeof fullApi,
+	FunctionReference<any, "internal">
 >;

--- a/apps/www/convex/_generated/dataModel.d.ts
+++ b/apps/www/convex/_generated/dataModel.d.ts
@@ -9,13 +9,13 @@
  */
 
 import type {
-  DataModelFromSchemaDefinition,
-  DocumentByName,
-  TableNamesInDataModel,
-  SystemTableNames,
+	DataModelFromSchemaDefinition,
+	DocumentByName,
+	SystemTableNames,
+	TableNamesInDataModel,
 } from "convex/server";
 import type { GenericId } from "convex/values";
-import schema from "../schema.js";
+import type schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
@@ -28,8 +28,8 @@ export type TableNames = TableNamesInDataModel<DataModel>;
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Doc<TableName extends TableNames> = DocumentByName<
-  DataModel,
-  TableName
+	DataModel,
+	TableName
 >;
 
 /**
@@ -46,7 +46,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
-  GenericId<TableName>;
+	GenericId<TableName>;
 
 /**
  * A type describing your Convex data model.

--- a/apps/www/convex/_generated/server.d.ts
+++ b/apps/www/convex/_generated/server.d.ts
@@ -8,16 +8,16 @@
  * @module
  */
 
-import {
-  ActionBuilder,
-  HttpActionBuilder,
-  MutationBuilder,
-  QueryBuilder,
-  GenericActionCtx,
-  GenericMutationCtx,
-  GenericQueryCtx,
-  GenericDatabaseReader,
-  GenericDatabaseWriter,
+import type {
+	ActionBuilder,
+	GenericActionCtx,
+	GenericDatabaseReader,
+	GenericDatabaseWriter,
+	GenericMutationCtx,
+	GenericQueryCtx,
+	HttpActionBuilder,
+	MutationBuilder,
+	QueryBuilder,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
 

--- a/apps/www/convex/_generated/server.js
+++ b/apps/www/convex/_generated/server.js
@@ -9,13 +9,13 @@
  */
 
 import {
-  actionGeneric,
-  httpActionGeneric,
-  queryGeneric,
-  mutationGeneric,
-  internalActionGeneric,
-  internalMutationGeneric,
-  internalQueryGeneric,
+	actionGeneric,
+	httpActionGeneric,
+	internalActionGeneric,
+	internalMutationGeneric,
+	internalQueryGeneric,
+	mutationGeneric,
+	queryGeneric,
 } from "convex/server";
 
 /**

--- a/apps/www/convex/schema.ts
+++ b/apps/www/convex/schema.ts
@@ -102,7 +102,7 @@ export default defineSchema({
 		shareId: shareIdValidator,
 		accessedAt: v.number(),
 		ipHash: v.optional(ipHashValidator), // Deprecated: Previously used for rate limiting
-		userAgent: userAgentValidator,
+		userAgent: v.optional(userAgentValidator), // Deprecated: Previously used for logging
 		success: v.boolean(), // Whether the access was successful
 	})
 		.index("by_share_id", ["shareId"])

--- a/apps/www/convex/schema.ts
+++ b/apps/www/convex/schema.ts
@@ -101,11 +101,10 @@ export default defineSchema({
 	shareAccess: defineTable({
 		shareId: shareIdValidator,
 		accessedAt: v.number(),
-		ipHash: ipHashValidator, // Hashed IP for rate limiting
+		ipHash: v.optional(ipHashValidator), // Deprecated: Previously used for rate limiting
 		userAgent: userAgentValidator,
 		success: v.boolean(), // Whether the access was successful
 	})
 		.index("by_share_id", ["shareId"])
-		.index("by_share_time", ["shareId", "accessedAt"])
-		.index("by_ip_time", ["ipHash", "accessedAt"]),
+		.index("by_share_time", ["shareId", "accessedAt"]),
 });

--- a/apps/www/convex/share.ts
+++ b/apps/www/convex/share.ts
@@ -5,7 +5,6 @@ import { mutation, query } from "./_generated/server";
 import {
 	shareIdValidator,
 	shareSettingsValidator,
-	userAgentValidator,
 } from "./validators";
 
 export const shareThread = mutation({
@@ -136,11 +135,6 @@ export const updateShareSettings = mutation({
 export const logShareAccess = mutation({
 	args: {
 		shareId: shareIdValidator,
-		clientInfo: v.optional(
-			v.object({
-				userAgent: userAgentValidator,
-			}),
-		),
 	},
 	returns: v.object({ allowed: v.boolean() }),
 	handler: async (ctx, args) => {
@@ -158,7 +152,6 @@ export const logShareAccess = mutation({
 		await ctx.db.insert("shareAccess", {
 			shareId: args.shareId,
 			accessedAt: now,
-			userAgent: args.clientInfo?.userAgent,
 			success,
 		});
 

--- a/apps/www/src/components/chat/shared-chat-view.tsx
+++ b/apps/www/src/components/chat/shared-chat-view.tsx
@@ -12,31 +12,12 @@ interface SharedChatViewProps {
 	shareId: string;
 }
 
-function hashString(str: string): string {
-	let hash = 0;
-	for (let i = 0; i < str.length; i++) {
-		const char = str.charCodeAt(i);
-		hash = (hash << 5) - hash + char;
-		hash = hash & hash; // Convert to 32bit integer
-	}
-	return Math.abs(hash).toString(36);
-}
-
 export function SharedChatView({ shareId }: SharedChatViewProps) {
-	// Create a simple client fingerprint for rate limiting
+	// Client info for basic logging
 	const clientInfo = useMemo(() => {
 		if (typeof window === "undefined") return undefined;
 
-		// Create a basic fingerprint without tracking personal info
-		const fingerprint = [
-			navigator.userAgent,
-			screen.width,
-			screen.height,
-			new Date().getTimezoneOffset(),
-		].join("|");
-
 		return {
-			ipHash: hashString(fingerprint), // Client-side hash, not real IP
 			userAgent: navigator.userAgent.substring(0, 100), // Limit length
 		};
 	}, []);

--- a/apps/www/src/components/chat/shared-chat-view.tsx
+++ b/apps/www/src/components/chat/shared-chat-view.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertDescription } from "@lightfast/ui/components/ui/alert";
 import { ScrollArea } from "@lightfast/ui/components/ui/scroll-area";
 import { useMutation, useQuery } from "convex/react";
 import { AlertCircle, Info, Loader2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { MessageItem } from "./shared";
 
 interface SharedChatViewProps {
@@ -13,15 +13,6 @@ interface SharedChatViewProps {
 }
 
 export function SharedChatView({ shareId }: SharedChatViewProps) {
-	// Client info for basic logging
-	const clientInfo = useMemo(() => {
-		if (typeof window === "undefined") return undefined;
-
-		return {
-			userAgent: navigator.userAgent.substring(0, 100), // Limit length
-		};
-	}, []);
-
 	const logAccess = useMutation(api.share.logShareAccess);
 	const [accessAllowed, setAccessAllowed] = useState<boolean | null>(null);
 
@@ -33,7 +24,7 @@ export function SharedChatView({ shareId }: SharedChatViewProps) {
 	// Log access attempt on component mount
 	useEffect(() => {
 		if (accessAllowed === null) {
-			logAccess({ shareId, clientInfo })
+			logAccess({ shareId })
 				.then((result) => {
 					setAccessAllowed(result.allowed);
 				})
@@ -41,7 +32,7 @@ export function SharedChatView({ shareId }: SharedChatViewProps) {
 					setAccessAllowed(false);
 				});
 		}
-	}, [shareId, clientInfo, logAccess, accessAllowed]);
+	}, [shareId, logAccess, accessAllowed]);
 
 	// Show loading while checking access or loading data
 	if (accessAllowed === null || (accessAllowed && sharedData === undefined)) {


### PR DESCRIPTION
## Summary
Removes unnecessary data collection from the share access mutation to simplify the codebase and improve privacy.

Part of staging-to-main PR #286.

## Changes Made
- ✅ **Removed ipHash functionality**:
  - Eliminated rate limiting logic based on IP hashes
  - Removed ipHash parameter from logShareAccess mutation
  - Updated client code to not collect IP fingerprints
  
- ✅ **Removed userAgent functionality**:
  - Eliminated userAgent parameter from logShareAccess mutation
  - Updated client code to not collect userAgent data
  - Removed unnecessary imports and simplified code

- ✅ **Schema updates**:
  - Made both ipHash and userAgent fields optional for backward compatibility
  - Removed the by_ip_time index since it's no longer needed
  - Added deprecation comments

## Technical Details
The `logShareAccess` mutation is now greatly simplified - it only takes a `shareId` and simply checks if the shared thread exists and is public, logging basic access information (shareId, timestamp, success) without any personal data collection or rate limiting.

## Testing
- ✅ Build passes successfully
- ✅ All TypeScript errors resolved
- ✅ Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)