### PR TITLE
fix: resolve convex schema validation errors after merge

### DIFF
--- a/apps/www/convex/schema.ts
+++ b/apps/www/convex/schema.ts
@@ -13,13 +13,13 @@ import {
 	messageMetadataValidator,
 	messagePartsValidator,
 	messageStatusValidator,
-	messagesDeprecatedValidator,
 	mimeTypeValidator,
+	modelIdValidator,
+	modelProviderValidator,
 	roleValidator,
 	shareIdValidator,
 	shareSettingsValidator,
 	storageIdValidator,
-	threadDeprecatedValidator,
 	threadMetadataValidator,
 	titleValidator,
 	userAgentValidator,
@@ -64,7 +64,17 @@ export default defineSchema({
 		shareSettings: shareSettingsValidator,
 		metadata: v.optional(threadMetadataValidator),
 		// @deprecated fields - Do not use in new code
-		...threadDeprecatedValidator.fields,
+		createdAt: v.optional(v.number()),
+		isTitleGenerating: v.optional(v.boolean()),
+		lastMessageAt: v.optional(v.number()),
+		isGenerating: v.optional(v.boolean()),
+		usage: v.optional(
+			v.object({
+				inputTokens: v.optional(v.number()),
+				outputTokens: v.optional(v.number()),
+				totalTokens: v.optional(v.number()),
+			}),
+		),
 	})
 		.index("by_user", ["userId"])
 		.index("by_client_id", ["clientId"])
@@ -81,7 +91,41 @@ export default defineSchema({
 		// New metadata structure
 		metadata: v.optional(messageMetadataValidator),
 		// @deprecated fields - Do not use in new code
-		...messagesDeprecatedValidator.fields,
+		messageType: v.optional(roleValidator),
+		modelId: v.optional(modelIdValidator),
+		usedUserApiKey: v.optional(v.boolean()),
+		thinkingStartedAt: v.optional(v.number()),
+		thinkingCompletedAt: v.optional(v.number()),
+		model: v.optional(modelProviderValidator),
+		timestamp: v.optional(v.number()),
+		body: v.optional(v.string()),
+		isStreaming: v.optional(v.boolean()),
+		streamId: v.optional(v.string()),
+		isComplete: v.optional(v.boolean()),
+		streamVersion: v.optional(v.number()),
+		thinkingContent: v.optional(v.string()),
+		isThinking: v.optional(v.boolean()),
+		hasThinkingContent: v.optional(v.boolean()),
+		usage: v.optional(
+			v.object({
+				inputTokens: v.optional(v.number()),
+				outputTokens: v.optional(v.number()),
+				totalTokens: v.optional(v.number()),
+			}),
+		),
+		streamChunks: v.optional(
+			v.array(
+				v.object({
+					chunkId: v.optional(v.string()),
+					id: v.optional(v.string()),
+					content: v.string(),
+					timestamp: v.number(),
+					sequence: v.optional(v.number()),
+					isThinking: v.optional(v.boolean()),
+				}),
+			),
+		),
+		lastChunkId: v.optional(v.string()),
 	}).index("by_thread", ["threadId"]),
 
 	feedback: defineTable({

--- a/apps/www/convex/share.ts
+++ b/apps/www/convex/share.ts
@@ -2,10 +2,7 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 import { nanoid } from "nanoid";
 import { mutation, query } from "./_generated/server";
-import {
-	shareIdValidator,
-	shareSettingsValidator,
-} from "./validators";
+import { shareIdValidator, shareSettingsValidator } from "./validators";
 
 export const shareThread = mutation({
 	args: {

--- a/apps/www/src/components/chat/shared-chat-view.tsx
+++ b/apps/www/src/components/chat/shared-chat-view.tsx
@@ -20,7 +20,10 @@ export function SharedChatView({ shareId }: SharedChatViewProps) {
 	);
 
 	// Show loading while checking access or loading data
-	if (threadCheck === undefined || (threadCheck?.allowed && sharedData === undefined)) {
+	if (
+		threadCheck === undefined ||
+		(threadCheck?.allowed && sharedData === undefined)
+	) {
 		return (
 			<div className="flex items-center justify-center h-screen">
 				<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/apps/www/src/components/chat/unified-model-selector.tsx
+++ b/apps/www/src/components/chat/unified-model-selector.tsx
@@ -1,25 +1,25 @@
 "use client";
 
 import {
-  type ModelId,
-  PROVIDER_ICONS,
-  getModelConfig,
-  getVisibleModels,
+	type ModelId,
+	PROVIDER_ICONS,
+	getModelConfig,
+	getVisibleModels,
 } from "@lightfast/ai/providers";
 import { Badge } from "@lightfast/ui/components/ui/badge";
 import { Button } from "@lightfast/ui/components/ui/button";
 import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList,
+	Command,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
 } from "@lightfast/ui/components/ui/command";
 import { Icons } from "@lightfast/ui/components/ui/icons";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
 } from "@lightfast/ui/components/ui/popover";
 import { cn } from "@lightfast/ui/lib/utils";
 import { ChevronDown } from "lucide-react";


### PR DESCRIPTION
## Summary
- Fixed schema validation errors by properly expanding deprecated field validators
- Resolved build failures caused by incorrect .fields property usage

## Problem
After the recent merge from staging to main, the schema validation was failing because the code was trying to use `.fields` property on validators that were defined as `v.object()`, which doesn't have a `.fields` property.

## Solution
- Replaced `...threadDeprecatedValidator.fields` with explicit deprecated fields inline
- Replaced `...messagesDeprecatedValidator.fields` with explicit deprecated fields inline
- Added missing imports for `modelIdValidator` and `modelProviderValidator`

## Testing
- ✅ Build completes successfully with `pnpm run build`
- ✅ Convex codegen works with `npx convex codegen`
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)