### PR TITLE
fix: add missing fields to usage validator in schema

### DIFF
--- a/apps/www/convex/_generated/api.d.ts
+++ b/apps/www/convex/_generated/api.d.ts
@@ -9,9 +9,9 @@
  */
 
 import type {
-	ApiFromModules,
-	FilterApi,
-	FunctionReference,
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
 } from "convex/server";
 import type * as auth from "../auth.js";
 import type * as env from "../env.js";
@@ -47,36 +47,36 @@ import type * as validators from "../validators.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
-	auth: typeof auth;
-	env: typeof env;
-	feedback: typeof feedback;
-	files: typeof files;
-	http: typeof http;
-	httpStreaming: typeof httpStreaming;
-	"lib/ai/client": typeof lib_ai_client;
-	"lib/ai/writer/message_part_writer": typeof lib_ai_writer_message_part_writer;
-	"lib/auth": typeof lib_auth;
-	"lib/capability_guards": typeof lib_capability_guards;
-	"lib/create_system_prompt": typeof lib_create_system_prompt;
-	"lib/database": typeof lib_database;
-	"lib/error_handling": typeof lib_error_handling;
-	"lib/errors": typeof lib_errors;
-	"lib/services/encryption": typeof lib_services_encryption;
-	messages: typeof messages;
-	setup: typeof setup;
-	share: typeof share;
-	threads: typeof threads;
-	titles: typeof titles;
-	types: typeof types;
-	userSettings: typeof userSettings;
-	users: typeof users;
-	validators: typeof validators;
+  auth: typeof auth;
+  env: typeof env;
+  feedback: typeof feedback;
+  files: typeof files;
+  http: typeof http;
+  httpStreaming: typeof httpStreaming;
+  "lib/ai/client": typeof lib_ai_client;
+  "lib/ai/writer/message_part_writer": typeof lib_ai_writer_message_part_writer;
+  "lib/auth": typeof lib_auth;
+  "lib/capability_guards": typeof lib_capability_guards;
+  "lib/create_system_prompt": typeof lib_create_system_prompt;
+  "lib/database": typeof lib_database;
+  "lib/error_handling": typeof lib_error_handling;
+  "lib/errors": typeof lib_errors;
+  "lib/services/encryption": typeof lib_services_encryption;
+  messages: typeof messages;
+  setup: typeof setup;
+  share: typeof share;
+  threads: typeof threads;
+  titles: typeof titles;
+  types: typeof types;
+  userSettings: typeof userSettings;
+  users: typeof users;
+  validators: typeof validators;
 }>;
 export declare const api: FilterApi<
-	typeof fullApi,
-	FunctionReference<any, "public">
+  typeof fullApi,
+  FunctionReference<any, "public">
 >;
 export declare const internal: FilterApi<
-	typeof fullApi,
-	FunctionReference<any, "internal">
+  typeof fullApi,
+  FunctionReference<any, "internal">
 >;

--- a/apps/www/convex/_generated/dataModel.d.ts
+++ b/apps/www/convex/_generated/dataModel.d.ts
@@ -9,13 +9,13 @@
  */
 
 import type {
-	DataModelFromSchemaDefinition,
-	DocumentByName,
-	SystemTableNames,
-	TableNamesInDataModel,
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
 } from "convex/server";
 import type { GenericId } from "convex/values";
-import type schema from "../schema.js";
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
@@ -28,8 +28,8 @@ export type TableNames = TableNamesInDataModel<DataModel>;
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Doc<TableName extends TableNames> = DocumentByName<
-	DataModel,
-	TableName
+  DataModel,
+  TableName
 >;
 
 /**
@@ -46,7 +46,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
-	GenericId<TableName>;
+  GenericId<TableName>;
 
 /**
  * A type describing your Convex data model.

--- a/apps/www/convex/_generated/server.d.ts
+++ b/apps/www/convex/_generated/server.d.ts
@@ -8,16 +8,16 @@
  * @module
  */
 
-import type {
-	ActionBuilder,
-	GenericActionCtx,
-	GenericDatabaseReader,
-	GenericDatabaseWriter,
-	GenericMutationCtx,
-	GenericQueryCtx,
-	HttpActionBuilder,
-	MutationBuilder,
-	QueryBuilder,
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
 

--- a/apps/www/convex/_generated/server.js
+++ b/apps/www/convex/_generated/server.js
@@ -9,13 +9,13 @@
  */
 
 import {
-	actionGeneric,
-	httpActionGeneric,
-	internalActionGeneric,
-	internalMutationGeneric,
-	internalQueryGeneric,
-	mutationGeneric,
-	queryGeneric,
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
 } from "convex/server";
 
 /**

--- a/apps/www/convex/schema.ts
+++ b/apps/www/convex/schema.ts
@@ -73,6 +73,8 @@ export default defineSchema({
 				inputTokens: v.optional(v.number()),
 				outputTokens: v.optional(v.number()),
 				totalTokens: v.optional(v.number()),
+				reasoningTokens: v.optional(v.number()),
+				cachedInputTokens: v.optional(v.number()),
 			}),
 		),
 	})
@@ -111,6 +113,8 @@ export default defineSchema({
 				inputTokens: v.optional(v.number()),
 				outputTokens: v.optional(v.number()),
 				totalTokens: v.optional(v.number()),
+				reasoningTokens: v.optional(v.number()),
+				cachedInputTokens: v.optional(v.number()),
 			}),
 		),
 		streamChunks: v.optional(


### PR DESCRIPTION
## Summary
Added missing fields to the usage validator to fix schema validation errors during deployment.

## Problem
The deployment was failing with schema validation errors:
```
Object contains extra field cachedInputTokens that is not in the validator
Object contains extra field reasoningTokens that is not in the validator
```

The actual usage data structure contains:
```javascript
{
  cachedInputTokens: 0,
  inputTokens: 82,
  outputTokens: 1034,
  reasoningTokens: 0,
  totalTokens: 1116,
}
```

## Solution
Updated the usage validator in both `threads` and `messages` tables to include:
- `reasoningTokens: v.optional(v.number())`
- `cachedInputTokens: v.optional(v.number())`

## Testing
- ✅ Build completes successfully
- ✅ Convex codegen works
- ✅ Schema now matches the actual data structure

🤖 Generated with [Claude Code](https://claude.ai/code)