### PR TITLE
fix: complete schema validation for threads usage field

### DIFF
--- a/apps/www/convex/schema.ts
+++ b/apps/www/convex/schema.ts
@@ -70,11 +70,32 @@ export default defineSchema({
 		isGenerating: v.optional(v.boolean()),
 		usage: v.optional(
 			v.object({
+				// Old simple format fields (for backward compatibility)
 				inputTokens: v.optional(v.number()),
 				outputTokens: v.optional(v.number()),
 				totalTokens: v.optional(v.number()),
 				reasoningTokens: v.optional(v.number()),
 				cachedInputTokens: v.optional(v.number()),
+				// New aggregated format fields
+				totalInputTokens: v.optional(v.number()),
+				totalOutputTokens: v.optional(v.number()),
+				totalReasoningTokens: v.optional(v.number()),
+				totalCachedInputTokens: v.optional(v.number()),
+				messageCount: v.optional(v.number()),
+				// Model-specific stats
+				modelStats: v.optional(
+					v.record(
+						v.string(),
+						v.object({
+							inputTokens: v.number(),
+							outputTokens: v.number(),
+							totalTokens: v.number(),
+							reasoningTokens: v.number(),
+							cachedInputTokens: v.number(),
+							messageCount: v.number(),
+						}),
+					),
+				),
 			}),
 		),
 	})

--- a/apps/www/convex/validators.ts
+++ b/apps/www/convex/validators.ts
@@ -236,6 +236,20 @@ export const threadUsageValidator = v.optional(
 		totalReasoningTokens: v.number(),
 		totalCachedInputTokens: v.number(),
 		messageCount: v.number(),
+		// Model-specific stats
+		modelStats: v.optional(
+			v.record(
+				v.string(),
+				v.object({
+					inputTokens: v.number(),
+					outputTokens: v.number(),
+					totalTokens: v.number(),
+					reasoningTokens: v.number(),
+					cachedInputTokens: v.number(),
+					messageCount: v.number(),
+				}),
+			),
+		),
 	}),
 );
 


### PR DESCRIPTION
## Summary
Comprehensive fix for schema validation errors in the threads table usage field.

## Problem
Deployment was failing with:
```
Object contains extra field messageCount that is not in the validator
```

The actual usage data in threads table has a complex structure:
```javascript
{
  messageCount: 1,
  modelStats: {
    "o3-mini": {
      cachedInputTokens: 0,
      inputTokens: 201,
      messageCount: 1,
      outputTokens: 1213,
      reasoningTokens: 768,
      totalTokens: 1414
    }
  },
  totalCachedInputTokens: 0,
  totalInputTokens: 201,
  totalOutputTokens: 1213,
  totalReasoningTokens: 768,
  totalTokens: 1414
}
```

## Solution
1. Updated `threadUsageValidator` to include `modelStats` field with per-model statistics
2. Updated the deprecated `usage` field in threads table to support:
   - Old format fields (backward compatibility): inputTokens, outputTokens, totalTokens
   - New aggregated fields: totalInputTokens, totalOutputTokens, totalReasoningTokens, etc.
   - Model-specific stats: modelStats record with per-model token usage

## Testing
- ✅ Build completes successfully
- ✅ Convex codegen works
- ✅ Schema now matches ALL fields in actual data

🤖 Generated with [Claude Code](https://claude.ai/code)