### PR TITLE
feat: add simplified chat landing following playground pattern

### DIFF
--- a/apps/www/src/components/chat/chat-interface.tsx
+++ b/apps/www/src/components/chat/chat-interface.tsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { api } from "../../../convex/_generated/api";
 import { convertDbMessagesToUIMessages } from "../../hooks/convertDbMessagesToUIMessages";
 import { useChat } from "../../hooks/use-chat";
-import { CenteredChatStart } from "./centered-chat-start";
+import { SimpleChatStart } from "./simple-chat-start";
 import { ChatInput } from "./chat-input";
 import { ChatMessages } from "./chat-messages";
 
@@ -49,7 +49,7 @@ export function ChatInterface() {
 	// Show centered layout only for new chats with no messages
 	if (pathInfo.type === "new" && !dbMessages) {
 		return (
-			<CenteredChatStart
+			<SimpleChatStart
 				onSendMessage={sendMessage}
 				dbMessages={dbMessages}
 				defaultModel={defaultModel}

--- a/apps/www/src/components/chat/simple-chat-start.tsx
+++ b/apps/www/src/components/chat/simple-chat-start.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useAuth } from "@/hooks/use-auth";
+import { useTimeGreeting } from "@/hooks/use-time-greeting";
+import type { TimezoneData } from "@/lib/timezone-cookies";
+import type { ModelId } from "@lightfast/ai/providers";
+import type { Preloaded } from "convex/react";
+import { usePreloadedQuery } from "convex/react";
+import type { api } from "../../../convex/_generated/api";
+import type { Doc } from "../../../convex/_generated/dataModel";
+import type { LightfastUIMessageOptions } from "../../hooks/convertDbMessagesToUIMessages";
+import { ChatInput } from "./chat-input";
+
+interface SimpleChatStartProps {
+	onSendMessage: (options: LightfastUIMessageOptions) => Promise<void> | void;
+	dbMessages?: Doc<"messages">[] | undefined;
+	preloadedUser?: Preloaded<typeof api.users.current>;
+	defaultModel?: ModelId;
+	serverTimezone?: TimezoneData | null;
+	ipEstimate?: string;
+	serverGreeting?: {
+		greeting: string;
+		timezone: string;
+		source: "cookie" | "ip" | "fallback";
+	};
+}
+
+export function SimpleChatStart({
+	onSendMessage,
+	dbMessages,
+	preloadedUser,
+	defaultModel,
+	serverTimezone,
+	ipEstimate,
+	serverGreeting,
+}: SimpleChatStartProps) {
+	const { displayName, email } = useAuth();
+	// Use server greeting if available to avoid client-side bounce
+	const clientGreetingInfo = useTimeGreeting(serverTimezone, ipEstimate);
+	const greeting = serverGreeting?.greeting || clientGreetingInfo.greeting;
+
+	// Use preloaded user data if available, otherwise fall back to regular auth hook
+	const preloadedUserData = preloadedUser
+		? usePreloadedQuery(preloadedUser)
+		: null;
+
+	const userEmail =
+		preloadedUserData?.email || email || displayName || "there";
+
+	return (
+		<div className="h-screen flex flex-col relative">
+			<div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+				<div className="w-full max-w-3xl px-4 pointer-events-auto">
+					<div className="mb-6 px-3">
+						<p className="text-2xl">
+							{greeting}, {userEmail}
+						</p>
+					</div>
+					<ChatInput
+						onSendMessage={onSendMessage}
+						placeholder="How can I help you today?"
+						dbMessages={dbMessages}
+						showDisclaimer={false}
+						defaultModel={defaultModel}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a new simplified chat landing page that follows the playground app structure but with personalized greetings.

## Changes

### New Component: SimpleChatStart
- **Centered layout**: Full-screen centered positioning like playground
- **Personalized greeting**: Shows "Good morning, user@example.com" without icon
- **Clean structure**: Simple greeting + chat input, no prompt suggestions
- **Maintains functionality**: All existing chat features preserved

### Updated ChatInterface
- Switches from CenteredChatStart to SimpleChatStart for new chats
- Cleaner, more minimal first impression
- Follows playground app pattern for consistency

## Design Decisions

**Following playground structure:**
- Absolute positioning with centered content
- Simple heading + input layout
- No complex suggestions or animations

**Personalized without complexity:**
- Time-based greeting (Good morning/afternoon/evening)
- Shows user email instead of generic text
- Removes lightning icon for cleaner look

## Comparison

**Before (CenteredChatStart):**
- ⚡ Good morning, user@example.com (with icon)
- Category-based prompt suggestions with animations
- Progressive disclosure interaction

**After (SimpleChatStart):**  
- Good morning, user@example.com (no icon)
- Direct chat input
- Cleaner, more focused experience

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>