### PR TITLE
fix: complete auth redirect cleanup and add CLERK_JWT_ISSUER_DOMAIN env var

### DIFF
--- a/apps/www/convex/auth.config.ts
+++ b/apps/www/convex/auth.config.ts
@@ -2,13 +2,14 @@
  * Clerk authentication configuration for Convex
  * This file configures Clerk as the authentication provider for Convex
  */
+import { env } from "./env";
 
 export default {
 	providers: [
 		{
 			// The issuer domain from your Clerk JWT template
 			// This should match the Issuer URL from your Clerk dashboard JWT template
-			domain: "https://clerk.lightfast.ai",
+			domain: env.CLERK_JWT_ISSUER_DOMAIN,
 			// Must be exactly "convex" as configured in Clerk dashboard JWT template
 			applicationID: "convex",
 		},

--- a/apps/www/convex/env.ts
+++ b/apps/www/convex/env.ts
@@ -16,6 +16,10 @@ export const env = createEnv({
 		EXA_API_KEY: z.string().min(1).describe("Exa API key for web search"),
 
 		// Authentication & Encryption
+		CLERK_JWT_ISSUER_DOMAIN: z
+			.string()
+			.min(1)
+			.describe("Clerk JWT issuer domain for authentication"),
 		JWT_PRIVATE_KEY: z
 			.string()
 			.min(1)

--- a/apps/www/src/app/actions/auth.ts
+++ b/apps/www/src/app/actions/auth.ts
@@ -33,7 +33,7 @@ export async function signInAction(formData: FormData) {
 	} catch (error) {
 		if (error instanceof z.ZodError) {
 			redirect(
-				`/signin?error=${encodeURIComponent("Invalid sign in parameters")}`,
+				`/sign-in?error=${encodeURIComponent("Invalid sign in parameters")}`,
 			);
 		}
 
@@ -44,7 +44,7 @@ export async function signInAction(formData: FormData) {
 
 		console.error("Sign in error:", error);
 		redirect(
-			`/signin?error=${encodeURIComponent("Failed to sign in. Please try again.")}`,
+			`/sign-in?error=${encodeURIComponent("Failed to sign in. Please try again.")}`,
 		);
 	}
 }

--- a/apps/www/src/app/auth/loading/page.tsx
+++ b/apps/www/src/app/auth/loading/page.tsx
@@ -9,9 +9,9 @@ export default async function AuthLoadingPage({
 	searchParams: Promise<{ provider?: string; redirectTo?: string }>;
 }) {
 	const params = await searchParams;
-	// If no provider is specified, redirect to signin
+	// If no provider is specified, redirect to sign-in
 	if (!params.provider) {
-		redirect("/signin");
+		redirect("/sign-in");
 	}
 
 	return (

--- a/apps/www/src/app/settings/error.tsx
+++ b/apps/www/src/app/settings/error.tsx
@@ -46,7 +46,7 @@ export default function SettingsError({
 		},
 		isAuthError && {
 			label: "Sign in",
-			href: "/signin",
+			href: "/sign-in",
 		},
 	].filter(Boolean) as ErrorBoundaryAction[];
 

--- a/apps/www/src/middleware.ts
+++ b/apps/www/src/middleware.ts
@@ -5,12 +5,11 @@ const isPublicRoute = createRouteMatcher([
 	"/",
 	"/sign-in(.*)",
 	"/sign-up(.*)",
-	"/signin(.*)", // Keep old route for backward compatibility
 	"/api/health",
 	"/api/webhooks(.*)",
 ]);
 
-const isSignInPage = createRouteMatcher(["/sign-in", "/signin"]);
+const isSignInPage = createRouteMatcher(["/sign-in"]);
 
 export default clerkMiddleware(async (auth, req) => {
 	const { pathname } = req.nextUrl;


### PR DESCRIPTION
## Summary
- Fixed ALL remaining /signin references to use /sign-in consistently
- Added CLERK_JWT_ISSUER_DOMAIN environment variable to Convex env.ts
- Updated auth.config.ts to use environment variable instead of hardcoded domain
- Removed backward compatibility for /signin route in middleware

## Changes
- Fixed auth.ts error redirects
- Fixed settings/error.tsx sign-in link
- Fixed auth/loading/page.tsx redirect
- Cleaned up middleware.ts to remove /signin support
- Added CLERK_JWT_ISSUER_DOMAIN to convex/env.ts
- Updated convex/auth.config.ts to use env variable

## Testing
- Build succeeds with `pnpm with-env pnpm run build`
- All auth redirects now consistently use /sign-in
- Clerk JWT issuer domain is now configurable via environment variable

🤖 Generated with [Claude Code](https://claude.ai/code)