### PR TITLE
feat: update all Convex queries to use Clerk user IDs directly

### DIFF
--- a/apps/www/convex/lib/auth.ts
+++ b/apps/www/convex/lib/auth.ts
@@ -81,6 +81,31 @@ export async function getAuthenticatedUserId(
 }
 
 /**
+ * Get authenticated Clerk user ID
+ * Returns the Clerk user ID directly without mapping
+ * @throws ConvexError with code "UNAUTHORIZED" if not authenticated
+ */
+export async function getAuthenticatedClerkUserId(
+	ctx:
+		| GenericQueryCtx<DataModel>
+		| GenericMutationCtx<DataModel>
+		| GenericActionCtx<DataModel>,
+): Promise<string> {
+	// Get the Clerk user identity
+	const identity = await ctx.auth.getUserIdentity();
+	
+	if (!identity) {
+		throw new ConvexError({
+			code: "UNAUTHORIZED",
+			message: "Not authenticated",
+		});
+	}
+
+	// Return the Clerk user ID directly
+	return identity.subject;
+}
+
+/**
  * Check if a user owns a resource
  * @throws ConvexError with code "FORBIDDEN" if user doesn't own the resource
  */

--- a/apps/www/convex/schema.ts
+++ b/apps/www/convex/schema.ts
@@ -104,6 +104,7 @@ export default defineSchema({
 		.index("by_clerk_user", ["clerkUserId"])
 		.index("by_client_id", ["clientId"])
 		.index("by_user_client", ["userId", "clientId"])
+		.index("by_clerk_user_client", ["clerkUserId", "clientId"])
 		.index("by_share_id", ["shareId"]),
 
 	messages: defineTable({

--- a/apps/www/convex/threads.ts
+++ b/apps/www/convex/threads.ts
@@ -2,9 +2,9 @@ import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
-import { mutation, query, type MutationCtx } from "./_generated/server.js";
-import { getAuthenticatedUserId } from "./lib/auth.js";
-import { getWithOwnership } from "./lib/database.js";
+import { mutation, query } from "./_generated/server.js";
+import { getAuthenticatedUserId, getAuthenticatedClerkUserId } from "./lib/auth.js";
+import { getWithClerkOwnership } from "./lib/database.js";
 import {
 	clientIdValidator,
 	clientThreadIdValidator,
@@ -12,57 +12,17 @@ import {
 	textPartValidator,
 } from "./validators.js";
 
-// Temporary user ID mapping for migration
-const USER_ID_TO_CLERK_MAPPING: Record<string, string> = {
-	"k9790x60x9wwg6t7xzg7sdbmj57hqa26": "user_30r1XMf2zFdlctUHRkyw9kir7u4",
-	"k97adp8es829yanjmkbqkyd3hs7hrhxe": "user_30zLsFGcSsOfimwJOAgdtlSO0ru",
-	"k97dt209wbz52xv87qqsjykqan7j2rfp": "user_30zLsGefNSjOERUW3IHo8fWFHHE",
-	"k972enf2bvfyk9ktytmhy0n6vd7j4fp8": "user_30zLsMvTa6YB9QTz3I9bWwdvXoP",
-	"k977vackk4cseqcmvxk4zvfnas7j66ev": "user_30zLsXOV9u76r633ihzrtu5qX2H",
-	"k973yvtmwffq5p6aa865zn35p57j7p90": "user_30zLscy5dYkvEZVI4iMYsIFACv7",
-	"k97c0cghpwypm4gxd143dxmmqd7j85ps": "user_30zLsqufawjJjc9qA0B0djm2BjS",
-	"k975rgx1d524qwycmvzxsx76w17j93fm": "user_30zLsvKKFHk5cVZLcbbMyuI0R8o",
-	"k97ebvm7xx71t9sqy3gt9ybhg57j9kca": "user_30zLt3tAzwbOSolvOQgE0oygtDf",
-	"k973j7j6b70ytwe51w5j6rfg7x7j80qt": "user_30zLtCGnPyUDNWF987j61MmPTFt",
-	"k97fevgv7sdde3q72x2zddqec57j95he": "user_30zLtC70oXk2LMzveWl0N4lLVRK",
-	"k978gnwyt3x385d28cq173pt4d7j973c": "user_30zLtMRCfr5oNai43SD3VChRILj",
-	"k9724c7tqr6d3pmzh2wxcvmd5h7j9yex": "user_30zLtQy8ylw3ngRwbXdVvtw9euG",
-	"k978vs6nz6q30p9jyg4peakahs7jb2gx": "user_30zLtWtDmF5U06ZZ1BmCdD2yCnm",
-	"k9778h9m3c47r92qs4m2mthem97jdebz": "user_30zLteNZqhW89PZPABopKD5WMN6",
-	"k97fk08bqasgyr563mr80n9xk57jgqhj": "user_30tqvw9R6sI8WN96yC8TVQUlRVl",
-	"k979kv70rb90ebjtwxbxe5r5q97jkmxt": "user_30zLtqqnmRvx5yVj7qpfRfSP7bF",
-	"k974dxda31s47y6pwygyazd4x97jjp1k": "user_30zLtstaIhXFD43oEHHZOsiBcUX",
-	"k9727yaev3p1hwqmrg7ws9hzyx7jj1tw": "user_30zLu3rD6fjwUHhAviP41vHNlkq",
-	"k979g52c5pbz6sm2hgn94yn9457jk0tm": "user_30zLuDxQsc9WKcJGEEvntzpWbHo",
-	"k972y2qhs55kw96knxqv75szt57jjjy8": "user_30zLuIeDMpBMVyoYl2VlOUJrU4O",
-	"k971h1ar6dzzkmdbxes91d3sfn7jjmy4": "user_30zLuR1Qn1zh8iismi4igecZlaU",
-	"k97a51c6s9be5kwecn80smmcm17jtbza": "user_30zLuVyvCEXZRtRU7Or9kwvcRr7",
-	"k978thj5gwg8c3mrxs10a9nwxn7jwn2g": "user_30zLuhUXdXINXJZvfZ6iKqYjnC3",
-	"k975mz471qckjxrc8p50qbx5kh7jybvj": "user_30zLugflpnRPktgYd5vBI8Pi7Mj",
-	"k979xsytsjva4kf77h7d7ssgk17k8bh3": "user_30zLun9qb8yW836LL9qXQbdJg7f",
-	"k97bg9b8991sxb5cb8gdjg88bn7kjcfa": "user_30zLux4MJMdS4uk3mGIK1UPouLi",
-	"k979w7a5a1y9vmpd9cgx0rbp7s7knjph": "user_30zLv1pC6RtzySxEJJ3vkmADnHp",
-	"k974mc23240emcz0qpgjejr8b17mcy51": "user_30zLv8SksvB7o1Qh4OOHA9eO9Dh",
-	"k9721nhjgvv6mtf97trycfkds97n4cyt": "user_30zLvIKdtM6icQxFyudBA9KNZiX",
-	"k97ad0sb79p39kt0recw4fb8cs7n5vy3": "user_30zLvUNywHUbkt8RHh7KgfvRRK4",
-};
-
-// Helper function to get Clerk user ID from Convex user ID
-async function getClerkUserIdForUser(_ctx: MutationCtx, userId: Id<"users">): Promise<string | undefined> {
-	// Direct mapping from Convex user ID to Clerk user ID
-	return USER_ID_TO_CLERK_MAPPING[userId];
-}
 
 // List initial threads for preloading (first 20)
 export const list = query({
 	args: {},
 	handler: async (ctx, _args) => {
 		try {
-			const userId = await getAuthenticatedUserId(ctx);
+			const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 			// Return first 20 threads for initial preload
 			return await ctx.db
 				.query("threads")
-				.withIndex("by_user", (q) => q.eq("userId", userId))
+				.withIndex("by_clerk_user", (q) => q.eq("clerkUserId", clerkUserId))
 				.order("desc")
 				.take(20);
 		} catch {
@@ -79,10 +39,10 @@ export const listForInfiniteScroll = query({
 		paginationOpts: paginationOptsValidator,
 	},
 	handler: async (ctx, args) => {
-		const userId = await getAuthenticatedUserId(ctx);
+		const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 		return await ctx.db
 			.query("threads")
-			.withIndex("by_user", (q) => q.eq("userId", userId))
+			.withIndex("by_clerk_user", (q) => q.eq("clerkUserId", clerkUserId))
 			.filter((q) => q.eq(q.field("pinned"), undefined)) // Only show threads where pinned is undefined (not false)
 			.order("desc")
 			.paginate(args.paginationOpts);
@@ -95,10 +55,10 @@ export const listPaginated = query({
 	},
 	handler: async (ctx, args) => {
 		try {
-			const userId = await getAuthenticatedUserId(ctx);
+			const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 			return await ctx.db
 				.query("threads")
-				.withIndex("by_user", (q) => q.eq("userId", userId))
+				.withIndex("by_clerk_user", (q) => q.eq("clerkUserId", clerkUserId))
 				.filter((q) => q.eq(q.field("pinned"), undefined)) // Only show threads where pinned is undefined (not false)
 				.order("desc")
 				.paginate(args.paginationOpts);
@@ -117,10 +77,10 @@ export const listPinned = query({
 	args: {},
 	handler: async (ctx, _args) => {
 		try {
-			const userId = await getAuthenticatedUserId(ctx);
+			const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 			return await ctx.db
 				.query("threads")
-				.withIndex("by_user", (q) => q.eq("userId", userId))
+				.withIndex("by_clerk_user", (q) => q.eq("clerkUserId", clerkUserId))
 				.filter((q) => q.eq(q.field("pinned"), true))
 				.order("desc")
 				.collect();
@@ -161,7 +121,9 @@ export const createThreadWithFirstMessages = mutation({
 		assistantMessageId: v.id("messages"),
 	}),
 	handler: async (ctx, args) => {
+		// Get both Convex and Clerk user IDs
 		const userId = await getAuthenticatedUserId(ctx);
+		const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 
 		// Check for collision if clientId is provided (extremely rare with nanoid)
 		const existing = await ctx.db
@@ -196,14 +158,11 @@ export const createThreadWithFirstMessages = mutation({
 			};
 		}
 
-		// Get the Clerk user ID for this user
-		const clerkUserId = await getClerkUserIdForUser(ctx, userId);
-
 		const threadId = await ctx.db.insert("threads", {
 			clientId: args.clientThreadId,
 			title: "", // Empty title indicates it's being generated
-			userId: userId,
-			clerkUserId: clerkUserId, // Add Clerk user ID
+			userId: userId, // Keep for backward compatibility
+			clerkUserId: clerkUserId, // Direct Clerk user ID
 			// Initialize metadata with usage tracking
 			metadata: {
 				usage: {
@@ -251,12 +210,12 @@ export const listPaginatedWithGrouping = query({
 	},
 	handler: async (ctx, args) => {
 		try {
-			const userId = await getAuthenticatedUserId(ctx);
+			const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 
 			// Build the query
 			let query = ctx.db
 				.query("threads")
-				.withIndex("by_user", (q) => q.eq("userId", userId))
+				.withIndex("by_clerk_user", (q) => q.eq("clerkUserId", clerkUserId))
 				.filter((q) => q.eq(q.field("pinned"), undefined)) // Only show threads where pinned is undefined (not false)
 				.order("desc");
 
@@ -269,7 +228,7 @@ export const listPaginatedWithGrouping = query({
 					const lastSkipped = itemsToSkip[itemsToSkip.length - 1];
 					query = ctx.db
 						.query("threads")
-						.withIndex("by_user", (q) => q.eq("userId", userId))
+						.withIndex("by_clerk_user", (q) => q.eq("clerkUserId", clerkUserId))
 						.filter((q) =>
 							q.and(
 								q.eq(q.field("pinned"), undefined),
@@ -311,8 +270,8 @@ export const get = query({
 	},
 	handler: async (ctx, args) => {
 		try {
-			const userId = await getAuthenticatedUserId(ctx);
-			return await getWithOwnership(ctx.db, "threads", args.threadId, userId);
+			const clerkUserId = await getAuthenticatedClerkUserId(ctx);
+			return await getWithClerkOwnership(ctx.db, "threads", args.threadId, clerkUserId);
 		} catch {
 			// Return null for unauthenticated users or threads they don't own
 			return null;
@@ -327,11 +286,11 @@ export const getByClientId = query({
 	},
 	handler: async (ctx, args) => {
 		try {
-			const userId = await getAuthenticatedUserId(ctx);
+			const clerkUserId = await getAuthenticatedClerkUserId(ctx);
 			const thread = await ctx.db
 				.query("threads")
-				.withIndex("by_user_client", (q) =>
-					q.eq("userId", userId).eq("clientId", args.clientId),
+				.withIndex("by_clerk_user_client", (q) =>
+					q.eq("clerkUserId", clerkUserId).eq("clientId", args.clientId),
 				)
 				.first();
 			return thread;
@@ -348,12 +307,12 @@ export const togglePinned = mutation({
 		threadId: v.id("threads"),
 	},
 	handler: async (ctx, args) => {
-		const userId = await getAuthenticatedUserId(ctx);
-		const thread = await getWithOwnership(
+		const clerkUserId = await getAuthenticatedClerkUserId(ctx);
+		const thread = await getWithClerkOwnership(
 			ctx.db,
 			"threads",
 			args.threadId,
-			userId,
+			clerkUserId,
 		);
 
 		const newPinnedState = !thread.pinned;

--- a/apps/www/convex/userSettings.ts
+++ b/apps/www/convex/userSettings.ts
@@ -1,6 +1,6 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
 import { ConvexError, v } from "convex/values";
 import { internalMutation, mutation, query } from "./_generated/server";
+import { getAuthenticatedUserId } from "./lib/auth";
 
 // Import proper encryption utilities
 import { decrypt, encrypt } from "./lib/services/encryption";
@@ -18,8 +18,10 @@ import {
 export const getUserSettings = query({
 	args: {},
 	handler: async (ctx) => {
-		const userId = await getAuthUserId(ctx);
-		if (!userId) {
+		let userId;
+		try {
+			userId = await getAuthenticatedUserId(ctx);
+		} catch {
 			return null;
 		}
 
@@ -45,10 +47,7 @@ export const updateApiKeys = mutation({
 	},
 	returns: v.object({ success: v.boolean() }),
 	handler: async (ctx, { openaiKey, anthropicKey, openrouterKey }) => {
-		const userId = await getAuthUserId(ctx);
-		if (!userId) {
-			throw new ConvexError("Unauthorized");
-		}
+		const userId = await getAuthenticatedUserId(ctx);
 
 		const existingSettings = await ctx.db
 			.query("userSettings")
@@ -113,10 +112,7 @@ export const updatePreferences = mutation({
 	},
 	returns: v.object({ success: v.boolean() }),
 	handler: async (ctx, { defaultModel, preferredProvider }) => {
-		const userId = await getAuthUserId(ctx);
-		if (!userId) {
-			throw new ConvexError("Unauthorized");
-		}
+		const userId = await getAuthenticatedUserId(ctx);
 
 		const existingSettings = await ctx.db
 			.query("userSettings")
@@ -157,10 +153,7 @@ export const removeApiKey = mutation({
 	returns: v.object({ success: v.boolean() }),
 	handler: async (ctx, args) => {
 		const provider = args.provider;
-		const userId = await getAuthUserId(ctx);
-		if (!userId) {
-			throw new ConvexError("Unauthorized");
-		}
+		const userId = await getAuthenticatedUserId(ctx);
 
 		const existingSettings = await ctx.db
 			.query("userSettings")

--- a/apps/www/convex/users.ts
+++ b/apps/www/convex/users.ts
@@ -1,6 +1,6 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 import { query } from "./_generated/server.js";
+import { getAuthenticatedUserId } from "./lib/auth.js";
 import {
 	emailValidator,
 	phoneValidator,
@@ -14,12 +14,14 @@ import {
 export const current = query({
 	args: {},
 	handler: async (ctx, _args) => {
-		const userId = await getAuthUserId(ctx);
-		if (!userId) {
+		try {
+			// Get the mapped Convex user ID using Clerk authentication
+			const userId = await getAuthenticatedUserId(ctx);
+			return await ctx.db.get(userId);
+		} catch {
+			// Return null for unauthenticated users
 			return null;
 		}
-
-		return await ctx.db.get(userId);
 	},
 });
 


### PR DESCRIPTION
## Summary
This PR completes the migration to Clerk authentication by updating all Convex queries to use Clerk user IDs directly instead of the old Convex user IDs.

## Changes

### New Functions
- Added `getAuthenticatedClerkUserId` to get Clerk ID without mapping
- Added `getWithClerkOwnership`, `updateWithClerkOwnership`, `deleteWithClerkOwnership` for Clerk-based ownership checks

### Updated Queries
- **threads.ts**: All queries now use `by_clerk_user` index
- **messages.ts**: Updated to use Clerk IDs for filtering
- **userSettings.ts**: Migrated from `@convex-dev/auth` to our auth functions
- **share.ts**: Updated ownership checks to support Clerk IDs
- **users.ts**: Updated to use mapped authentication

### Database Schema
- Added `by_clerk_user_client` compound index for efficient lookups

### Backward Compatibility
- All ownership checks now verify both `userId` and `clerkUserId` fields
- Maintains compatibility with existing data during migration

## Testing
- Build passes successfully
- All TypeScript checks pass
- Queries maintain backward compatibility

## Next Steps
- After verification in production, we can remove the old user ID mappings
- Consider migrating old records to only use Clerk IDs

🤖 Generated with [Claude Code](https://claude.ai/code)