### PR TITLE
fix: add clerkUserId to all thread operations and clean up unused code

### DIFF
--- a/apps/www/convex/setup.ts
+++ b/apps/www/convex/setup.ts
@@ -34,6 +34,7 @@ export const setupInitialData = mutation({
 		const threadId = await ctx.db.insert("threads", {
 			title: "Welcome to Lightfast Chat",
 			userId: testUserId,
+			clerkUserId: "user_2wOoxmHl3liuDMYwDZ9wVh9nsh7", // Use the provided Clerk user ID
 			metadata: {
 				usage: {
 					totalInputTokens: 0,

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"dev": "concurrently \"pnpm run with-env next dev\" \"pnpm run convex:dev\" --names \"next,convex\" --prefix-colors \"blue,green\"",
 		"dev:next": "pnpm run with-env next dev",
-		"build": "next build",
-		"start": "next start",
+		"build": "pnpm with-env next build",
+		"start": "pnpm with-env next start",
 		"lint": "biome check --write .",
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit",

--- a/apps/www/src/components/chat/chat-input.tsx
+++ b/apps/www/src/components/chat/chat-input.tsx
@@ -25,7 +25,6 @@ import {
 	FileIcon,
 	Globe,
 	Image,
-	Loader2,
 	Paperclip,
 	X,
 } from "lucide-react";

--- a/apps/www/src/components/chat/model-branch-dropdown.tsx
+++ b/apps/www/src/components/chat/model-branch-dropdown.tsx
@@ -1,43 +1,14 @@
 "use client";
 
-import { Brain, Eye, FileText, GitBranch, Wrench } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { GitBranch } from "lucide-react";
 
-import { getModelCapabilities } from "@/lib/ai/capabilities";
-import type { ModelConfig, ModelId } from "@lightfast/ai/providers";
-import { getVisibleModels } from "@lightfast/ai/providers";
+import type { ModelId } from "@lightfast/ai/providers";
 import { Button } from "@lightfast/ui/components/ui/button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuPortal,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
-	DropdownMenuTrigger,
-} from "@lightfast/ui/components/ui/dropdown-menu";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@lightfast/ui/components/ui/tooltip";
-
-// Icon component mapper for capability icons
-const CapabilityIcon = ({
-	iconName,
-	className,
-}: { iconName: string; className?: string }) => {
-	const iconMap = {
-		Eye,
-		FileText,
-		Wrench,
-		Brain,
-	} as const;
-
-	const IconComponent = iconMap[iconName as keyof typeof iconMap];
-	return IconComponent ? <IconComponent className={className} /> : null;
-};
 
 interface ModelBranchDropdownProps {
 	onBranch: (modelId: ModelId) => void;
@@ -45,50 +16,7 @@ interface ModelBranchDropdownProps {
 	onOpenChange?: (open: boolean) => void;
 }
 
-export function ModelBranchDropdown({
-	onBranch,
-	disabled = false,
-	onOpenChange,
-}: ModelBranchDropdownProps) {
-	const [open, setOpen] = useState(false);
-	const buttonRef = useRef<HTMLButtonElement>(null);
-
-	// Notify parent when dropdown state changes
-	useEffect(() => {
-		onOpenChange?.(open);
-
-		// Blur the button when dropdown closes to remove focus state
-		if (!open && buttonRef.current) {
-			buttonRef.current.blur();
-		}
-	}, [open, onOpenChange]);
-
-	// Group models by provider
-	const modelsByProvider = useMemo(() => {
-		const allModels = getVisibleModels();
-		return allModels.reduce(
-			(acc, model) => {
-				if (!acc[model.provider]) {
-					acc[model.provider] = [];
-				}
-				acc[model.provider].push(model);
-				return acc;
-			},
-			{} as Record<string, ModelConfig[]>,
-		);
-	}, []);
-
-	const handleModelSelect = (modelId: ModelId) => {
-		setOpen(false);
-		onBranch(modelId);
-	};
-
-	// Provider display names
-	const providerNames: Record<string, string> = {
-		openai: "OpenAI",
-		anthropic: "Anthropic",
-		openrouter: "OpenRouter",
-	};
+export function ModelBranchDropdown(_props: ModelBranchDropdownProps) {
 
 	return (
 		<Tooltip>

--- a/apps/www/src/hooks/use-create-thread-with-first-messages.ts
+++ b/apps/www/src/hooks/use-create-thread-with-first-messages.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useUser } from "@clerk/nextjs";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
@@ -12,6 +13,8 @@ import type { DbMessage, DbThread } from "../../convex/types";
 export function useCreateThreadWithFirstMessages() {
 	// Get the current user to use in optimistic updates
 	const currentUser = useQuery(api.users.current);
+	// Get the Clerk user for the clerkUserId field
+	const { user: clerkUser } = useUser();
 
 	return useMutation(
 		api.threads.createThreadWithFirstMessages,
@@ -20,7 +23,7 @@ export function useCreateThreadWithFirstMessages() {
 
 		// If we don't have a user ID yet, we can't create an optimistic thread
 		// This shouldn't happen in practice as the user should be authenticated
-		if (!currentUser?._id) {
+		if (!currentUser?._id || !clerkUser?.id) {
 			console.error("No user ID found");
 			return;
 		}
@@ -38,6 +41,7 @@ export function useCreateThreadWithFirstMessages() {
 			clientId: clientThreadId,
 			title: "",
 			userId: currentUser._id,
+			clerkUserId: clerkUser.id, // Use the actual Clerk user ID
 			pinned: undefined, // Match backend behavior - undefined means unpinned
 			branchedFrom: undefined,
 			isPublic: false,


### PR DESCRIPTION
## Summary
- Add clerkUserId field to setup.ts with proper Clerk user ID
- Fetch Clerk user ID directly from useUser hook for optimistic updates
- Remove unused imports and code
- Add with-env to build and start scripts

## Changes
- Updated setup.ts to include clerkUserId field with the provided ID
- Modified useCreateThreadWithFirstMessages hook to fetch Clerk user from @clerk/nextjs
- Removed unused imports: Loader2, CapabilityIcon, dropdown menu components
- Added with-env prefix to build and start scripts for proper env loading
- Cleaned up disabled dropdown functionality

## Testing
- Build now passes successfully with environment variables
- Thread creation works with proper Clerk user ID
- No TypeScript errors

🤖 Generated with Claude Code