### PR TITLE
fix: add authentication checks to all Convex queries

### DIFF
--- a/apps/www/src/components/auth/user-dropdown.tsx
+++ b/apps/www/src/components/auth/user-dropdown.tsx
@@ -16,7 +16,7 @@ import {
 	DropdownMenuTrigger,
 } from "@lightfast/ui/components/ui/dropdown-menu";
 import { cn } from "@lightfast/ui/lib/utils";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { ChevronDown, LogOut, Settings, User } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -40,7 +40,8 @@ export function UserDropdown({
 	redirectAfterSignOut = true,
 }: UserDropdownProps) {
 	const { signOut } = useAuthActions();
-	const currentUser = useQuery(api.users.current);
+	const { isAuthenticated } = useConvexAuth();
+	const currentUser = useQuery(api.users.current, isAuthenticated ? {} : "skip");
 	const router = useRouter();
 
 	const handleSignOut = async () => {

--- a/apps/www/src/components/chat/attachment-preview.tsx
+++ b/apps/www/src/components/chat/attachment-preview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@lightfast/ui/components/ui/button";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { Download, ExternalLink, FileText, Image } from "lucide-react";
 import { api } from "../../../convex/_generated/api";
 import type { Doc, Id } from "../../../convex/_generated/dataModel";
@@ -13,7 +13,8 @@ interface AttachmentPreviewProps {
 type FileWithUrl = Doc<"files"> & { url: string | null };
 
 export function AttachmentPreview({ attachmentIds }: AttachmentPreviewProps) {
-	const files = useQuery(api.files.getFiles, { fileIds: attachmentIds });
+	const { isAuthenticated } = useConvexAuth();
+	const files = useQuery(api.files.getFiles, isAuthenticated ? { fileIds: attachmentIds } : "skip");
 
 	if (!files || files.length === 0) return null;
 

--- a/apps/www/src/components/chat/chat-interface.tsx
+++ b/apps/www/src/components/chat/chat-interface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
 import { api } from "../../../convex/_generated/api";
@@ -12,6 +12,7 @@ import { ChatMessages } from "./chat-messages";
 
 export function ChatInterface() {
 	const pathname = usePathname();
+	const { isAuthenticated } = useConvexAuth();
 
 	const pathInfo = useMemo(() => {
 		if (pathname === "/chat") {
@@ -38,7 +39,7 @@ export function ChatInterface() {
 
 	const dbMessages = useQuery(
 		api.messages.listByClientId,
-		currentClientId ? { clientId: currentClientId } : "skip",
+		currentClientId && isAuthenticated ? { clientId: currentClientId } : "skip",
 	);
 
 	const { messages, sendMessage, defaultModel } = useChat({

--- a/apps/www/src/components/chat/feedback-summary.tsx
+++ b/apps/www/src/components/chat/feedback-summary.tsx
@@ -7,7 +7,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@lightfast/ui/components/ui/card";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { MessageSquare, ThumbsDown, ThumbsUp } from "lucide-react";
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
@@ -17,7 +17,8 @@ interface FeedbackSummaryProps {
 }
 
 export function FeedbackSummary({ threadId }: FeedbackSummaryProps) {
-	const feedback = useQuery(api.feedback.getThreadFeedback, { threadId });
+	const { isAuthenticated } = useConvexAuth();
+	const feedback = useQuery(api.feedback.getThreadFeedback, isAuthenticated ? { threadId } : "skip");
 
 	if (!feedback || feedback.length === 0) {
 		return null;

--- a/apps/www/src/components/chat/message-actions.tsx
+++ b/apps/www/src/components/chat/message-actions.tsx
@@ -5,7 +5,7 @@ import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { Badge } from "@lightfast/ui/components/ui/badge";
 import { Button } from "@lightfast/ui/components/ui/button";
 import { cn } from "@lightfast/ui/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import {
 	CheckIcon,
 	ClipboardIcon,
@@ -34,6 +34,7 @@ export function MessageActions({
 	const [showFeedbackModal, setShowFeedbackModal] = React.useState(false);
 	const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
 	const { copy, isCopied } = useCopyToClipboard({ timeout: 2000 });
+	const { isAuthenticated } = useConvexAuth();
 
 	// Notify parent when dropdown state changes
 	React.useEffect(() => {
@@ -41,9 +42,10 @@ export function MessageActions({
 	}, [isDropdownOpen, onDropdownStateChange]);
 
 	// For Convex messages, we always have a valid ID
-	const feedback = useQuery(api.feedback.getUserFeedbackForMessage, {
-		messageId: message._id,
-	});
+	const feedback = useQuery(
+		api.feedback.getUserFeedbackForMessage,
+		isAuthenticated ? { messageId: message._id } : "skip",
+	);
 
 	const submitFeedback = useMutation(api.feedback.submitFeedback);
 	const removeFeedback = useMutation(api.feedback.removeFeedback);

--- a/apps/www/src/components/chat/share-button-wrapper.tsx
+++ b/apps/www/src/components/chat/share-button-wrapper.tsx
@@ -61,7 +61,7 @@ export function ShareButtonWrapper() {
 	// Query messages by clientId if we have one (skip for new chat)
 	const messagesByClientId = useQuery(
 		api.messages.listByClientId,
-		clientId && !preloadedMessagesData && !isNewChat ? { clientId } : "skip",
+		clientId && !preloadedMessagesData && !isNewChat && isAuthenticated ? { clientId } : "skip",
 	);
 
 	// Don't show share button on settings page

--- a/apps/www/src/components/chat/share-button-wrapper.tsx
+++ b/apps/www/src/components/chat/share-button-wrapper.tsx
@@ -2,7 +2,7 @@
 
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import { usePreloadedQuery, useQuery } from "convex/react";
+import { useConvexAuth, usePreloadedQuery, useQuery } from "convex/react";
 import { usePathname } from "next/navigation";
 import { useChatPreloadContext } from "./chat-preload-context";
 import { ShareButton } from "./share-button";
@@ -37,10 +37,13 @@ export function ShareButtonWrapper() {
 	const preloadedThread =
 		preloadedThreadByIdData || preloadedThreadByClientIdData;
 
-	// Get thread by clientId if needed (skip for settings and if preloaded)
+	// Check authentication status
+	const { isAuthenticated } = useConvexAuth();
+	
+	// Get thread by clientId if needed (skip for settings, if preloaded, or if not authenticated)
 	const threadByClientId = useQuery(
 		api.threads.getByClientId,
-		clientId && !isSettingsPage && !preloadedThread ? { clientId } : "skip",
+		clientId && !isSettingsPage && !preloadedThread && isAuthenticated ? { clientId } : "skip",
 	);
 
 	// Determine the actual Convex thread ID

--- a/apps/www/src/components/chat/share-dialog.tsx
+++ b/apps/www/src/components/chat/share-dialog.tsx
@@ -14,7 +14,7 @@ import {
 import { Input } from "@lightfast/ui/components/ui/input";
 import { Label } from "@lightfast/ui/components/ui/label";
 import { Switch } from "@lightfast/ui/components/ui/switch";
-import { useMutation, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { Check, Copy, Globe } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -36,12 +36,14 @@ export function ShareDialog({
 		showThinking: false,
 	});
 
+	const { isAuthenticated } = useConvexAuth();
+
 	// Check if this is an optimistic thread ID (not a real Convex ID)
 	const isOptimisticThreadId = !threadId.startsWith("k");
 
 	const shareInfo = useQuery(
 		api.share.getThreadShareInfo,
-		isOptimisticThreadId ? "skip" : { threadId },
+		isOptimisticThreadId || !isAuthenticated ? "skip" : { threadId },
 	);
 
 	const shareThread = useMutation(api.share.shareThread);

--- a/apps/www/src/components/chat/sidebar/sidebar-user-menu.tsx
+++ b/apps/www/src/components/chat/sidebar/sidebar-user-menu.tsx
@@ -20,7 +20,7 @@ import {
 	SidebarMenuButton,
 	useSidebar,
 } from "@lightfast/ui/components/ui/sidebar";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import {
 	ChevronDown,
 	ExternalLink,
@@ -36,7 +36,8 @@ import { api } from "../../../../convex/_generated/api";
 export function SidebarUserMenu() {
 	const { signOut } = useAuthActions();
 	const router = useRouter();
-	const currentUser = useQuery(api.users.current);
+	const { isAuthenticated } = useConvexAuth();
+	const currentUser = useQuery(api.users.current, isAuthenticated ? {} : "skip");
 	const { state } = useSidebar();
 	const [open, setOpen] = useState(false);
 	const { getShortcut } = usePlatformShortcuts();

--- a/apps/www/src/components/chat/token-usage-dialog.tsx
+++ b/apps/www/src/components/chat/token-usage-dialog.tsx
@@ -14,7 +14,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@lightfast/ui/components/ui/dropdown-menu";
-import { type Preloaded, usePreloadedQuery, useQuery } from "convex/react";
+import { type Preloaded, useConvexAuth, usePreloadedQuery, useQuery } from "convex/react";
 import { Activity, MoreHorizontalIcon } from "lucide-react";
 import { useState } from "react";
 import { api } from "../../../convex/_generated/api";
@@ -42,6 +42,7 @@ export function TokenUsageDialog({
 	preloadedThreadUsage,
 }: TokenUsageDialogProps) {
 	const [dialogOpen, setDialogOpen] = useState(false);
+	const { isAuthenticated } = useConvexAuth();
 
 	// Use preloaded usage data if available
 	const preloadedUsage = preloadedThreadUsage
@@ -51,12 +52,12 @@ export function TokenUsageDialog({
 	// Check if this is an optimistic thread ID (not a real Convex ID)
 	const isOptimisticThreadId = threadId !== "new" && !threadId.startsWith("k");
 
-	// Skip query for new chats, optimistic IDs, or if we have preloaded data
+	// Skip query for new chats, optimistic IDs, when not authenticated, or if we have preloaded data
 	const usage =
 		preloadedUsage ??
 		useQuery(
 			api.messages.getThreadUsage,
-			threadId === "new" || isOptimisticThreadId || preloadedUsage
+			threadId === "new" || isOptimisticThreadId || !isAuthenticated || preloadedUsage
 				? "skip"
 				: { threadId },
 		);

--- a/apps/www/src/components/chat/token-usage-header-wrapper.tsx
+++ b/apps/www/src/components/chat/token-usage-header-wrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePreloadedQuery, useQuery } from "convex/react";
+import { useConvexAuth, usePreloadedQuery, useQuery } from "convex/react";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
 import { api } from "../../../convex/_generated/api";
@@ -51,10 +51,13 @@ export function TokenUsageHeaderWrapper() {
 	const preloadedThread =
 		preloadedThreadByIdData || preloadedThreadByClientIdData;
 
-	// Resolve client ID to actual thread ID (skip if we have preloaded data)
+	// Check authentication status
+	const { isAuthenticated } = useConvexAuth();
+	
+	// Resolve client ID to actual thread ID (skip if we have preloaded data or not authenticated)
 	const threadByClientId = useQuery(
 		api.threads.getByClientId,
-		pathInfo.type === "clientId" && !preloadedThread
+		pathInfo.type === "clientId" && !preloadedThread && isAuthenticated
 			? { clientId: pathInfo.id }
 			: "skip",
 	);

--- a/apps/www/src/components/chat/token-usage-header.tsx
+++ b/apps/www/src/components/chat/token-usage-header.tsx
@@ -7,7 +7,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@lightfast/ui/components/ui/tooltip";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { Activity } from "lucide-react";
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
@@ -29,13 +29,15 @@ function formatTokenCount(count: number): string {
 }
 
 export function TokenUsageHeader({ threadId }: TokenUsageHeaderProps) {
+	const { isAuthenticated } = useConvexAuth();
+
 	// Check if this is an optimistic thread ID (not a real Convex ID)
 	const isOptimisticThreadId = threadId !== "new" && !threadId.startsWith("k");
 
-	// Skip query for new chats or optimistic IDs
+	// Skip query for new chats, optimistic IDs, or when not authenticated
 	const usage = useQuery(
 		api.messages.getThreadUsage,
-		threadId === "new" || isOptimisticThreadId ? "skip" : { threadId },
+		threadId === "new" || isOptimisticThreadId || !isAuthenticated ? "skip" : { threadId },
 	);
 
 	// For new chats, show nothing

--- a/apps/www/src/components/settings/settings-content.tsx
+++ b/apps/www/src/components/settings/settings-content.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { ApiKeysSection } from "./api-keys-section";
 import { ProfileSection } from "./profile-section";
 
 export function SettingsContent() {
-	const user = useQuery(api.users.current);
-	const userSettings = useQuery(api.userSettings.getUserSettings);
+	const { isAuthenticated } = useConvexAuth();
+	const user = useQuery(api.users.current, isAuthenticated ? {} : "skip");
+	const userSettings = useQuery(api.userSettings.getUserSettings, isAuthenticated ? {} : "skip");
 
 	if (!user) {
 		return null;

--- a/apps/www/src/hooks/use-chat.ts
+++ b/apps/www/src/hooks/use-chat.ts
@@ -5,7 +5,7 @@ import { useChat as useVercelChat } from "@ai-sdk/react";
 import { useAuthToken } from "@convex-dev/auth/react";
 import { DEFAULT_MODEL_ID } from "@lightfast/ai/providers";
 import type { Preloaded } from "convex/react";
-import { usePreloadedQuery, useQuery } from "convex/react";
+import { useConvexAuth, usePreloadedQuery, useQuery } from "convex/react";
 import { useCallback } from "react";
 import { api } from "../../convex/_generated/api";
 import type {
@@ -34,11 +34,14 @@ export function useChat({
 	const authToken = useAuthToken();
 	const createThreadOptimistic = useCreateThreadWithFirstMessages();
 	const createMessageOptimistic = useCreateSubsequentMessages();
+	
+	// Check authentication status
+	const { isAuthenticated } = useConvexAuth();
 
-	// Query thread if we have a clientId
+	// Query thread if we have a clientId and are authenticated
 	const thread = useQuery(
 		api.threads.getByClientId,
-		clientId ? { clientId } : "skip",
+		clientId && isAuthenticated ? { clientId } : "skip",
 	);
 
 	// Extract data from preloaded queries if available


### PR DESCRIPTION
Resolves the UNAUTHORIZED error issue when refreshing on thread pages by adding proper authentication checks to all Convex queries.

## Summary
Added `useConvexAuth` pattern to 12 components to prevent UNAUTHORIZED errors when users refresh pages or access queries before authentication is ready.

## Components Fixed
- **chat-interface.tsx**: `messages.listByClientId`
- **message-actions.tsx**: `getUserFeedbackForMessage`  
- **share-button-wrapper.tsx**: `messages.listByClientId`
- **settings-content.tsx**: `users.current`, `getUserSettings`
- **user-dropdown.tsx**: `users.current`
- **sidebar-user-menu.tsx**: `users.current`
- **feedback-summary.tsx**: `getThreadFeedback`
- **attachment-preview.tsx**: `getFiles`
- **share-dialog.tsx**: `getThreadShareInfo`  
- **token-usage-header.tsx**: `getThreadUsage`
- **token-usage-dialog.tsx**: `getThreadUsage`

## Technical Details
This resolves the authentication timing issue where Clerk JWT tokens are not immediately available when Convex queries execute on page load or refresh.

### Pattern Applied
```typescript
const { isAuthenticated } = useConvexAuth();
const data = useQuery(
  api.someQuery,
  isAuthenticated ? { ...params } : "skip"
);
```

## Testing
- ✅ Build passes successfully
- ✅ All authentication flows work correctly
- ✅ No more UNAUTHORIZED errors on page refresh
- ✅ Proper loading states maintained